### PR TITLE
End to end latency calc bug

### DIFF
--- a/producer-c/producer-cloudwatch-integ/CanaryStreamUtils.cpp
+++ b/producer-c/producer-cloudwatch-integ/CanaryStreamUtils.cpp
@@ -132,11 +132,11 @@ STATUS canaryStreamFragmentAckHandler(UINT64 customData,
     UINT64 timeOfFragmentEndSent = pCanaryStreamCallbacks->timeOfNextKeyFrame->find(pFragmentAck->timestamp)->second;
 
     switch (pFragmentAck->ackType) {
-    case FRAGMENT_ACK_TYPE_BUFFERING:
+        case FRAGMENT_ACK_TYPE_BUFFERING:
             pCanaryStreamCallbacks->bufferingAckDatum.SetValue((GETTIME() - timeOfFragmentEndSent) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
             pCanaryStreamCallbacks->bufferingAckDatum.SetUnit(Aws::CloudWatch::Model::StandardUnit::Milliseconds);
             canaryStreamSendMetrics(pCanaryStreamCallbacks, pCanaryStreamCallbacks->bufferingAckDatum);
-    break;
+            break;
         case FRAGMENT_ACK_TYPE_RECEIVED:
             pCanaryStreamCallbacks->receivedAckDatum.SetValue((GETTIME() - timeOfFragmentEndSent) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
             pCanaryStreamCallbacks->receivedAckDatum.SetUnit(Aws::CloudWatch::Model::StandardUnit::Milliseconds);

--- a/producer-c/producer-cloudwatch-integ/KvsProducerSampleCloudwatch.cpp
+++ b/producer-c/producer-cloudwatch-integ/KvsProducerSampleCloudwatch.cpp
@@ -11,14 +11,13 @@ VOID sigintHandler(INT32 sigNum)
 // add frame pts, frame index, original frame size, CRC to beginning of buffer
 VOID addCanaryMetadataToFrameData(PFrame pFrame) {
     PBYTE pCurPtr = pFrame->frameData;
-    putUnalignedInt64(pCurPtr, pFrame->presentationTs / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+    putUnalignedInt64BigEndian((PINT64)pCurPtr, pFrame->presentationTs / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
     pCurPtr += SIZEOF(UINT64);
-    putUnalignedInt32(pCurPtr, pFrame->index);
+    putUnalignedInt32BigEndian((PINT32)pCurPtr, pFrame->index);
     pCurPtr += SIZEOF(UINT32);
-    putUnalignedInt32(pCurPtr, pFrame->size);
+    putUnalignedInt32BigEndian((PINT32)pCurPtr, pFrame->size);
     pCurPtr += SIZEOF(UINT32);
-    MEMSET(pCurPtr, 0x00, SIZEOF(UINT64));
-    putUnalignedInt64(pCurPtr, COMPUTE_CRC32(pFrame->frameData, pFrame->size));
+    putUnalignedInt32BigEndian((PINT32)pCurPtr, COMPUTE_CRC32(pFrame->frameData, pFrame->size));
 }
 
 VOID createCanaryFrameData(PFrame pFrame) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
A bug was introduced in calculating the end to end latency wherein negative values are observed if putUnalignedInt version calls are used. The PR includes a fix for this and few other cleanup

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
