### PR TITLE
Fix segfault due to valist in cloudwatch logger

### DIFF
--- a/producer-c/producer-cloudwatch-integ/CanaryLogsUtils.cpp
+++ b/producer-c/producer-cloudwatch-integ/CanaryLogsUtils.cpp
@@ -83,10 +83,10 @@ VOID cloudWatchLogger(UINT32 level, PCHAR tag, PCHAR fmt, ...)
         addLogMetadata(logFmtString, (UINT32) ARRAY_SIZE(logFmtString), fmt, level);
 
         // Creating a copy to store the logFmtString for cloudwatch logging purpose
-        va_list valist;
-        va_start(valist, fmt);
-        vsprintf(cwLogFmtString, logFmtString, valist);
-        va_end(valist);
+        va_list valist, valist_cw;
+        va_start(valist_cw, fmt);
+        vsnprintf(cwLogFmtString, (SIZE_T) SIZEOF(cwLogFmtString), logFmtString, valist_cw);
+        va_end(valist_cw);
         va_start(valist, fmt);
         vprintf(logFmtString, valist);
         va_end(valist);

--- a/producer-c/producer-cloudwatch-integ/KvsProducerSampleCloudwatch.cpp
+++ b/producer-c/producer-cloudwatch-integ/KvsProducerSampleCloudwatch.cpp
@@ -109,7 +109,7 @@ INT32 main(INT32 argc, CHAR *argv[])
         canaryTypeStr = getCanaryStr(canaryType);
         CHK(STRCMP(canaryTypeStr, "") != 0, STATUS_INVALID_ARG);
         SNPRINTF(streamName, MAX_STREAM_NAME_LEN, "%s-canary-%s-%s", streamNamePrefix, canaryTypeStr, argv[3]);
-        DLOGD("streamName:%s\n", streamName);
+
         if ((region = getenv(DEFAULT_REGION_ENV_VAR)) == NULL) {
             region = (PCHAR) DEFAULT_AWS_REGION;
         }

--- a/producer-c/producer-cloudwatch-integ/KvsProducerSampleCloudwatch.cpp
+++ b/producer-c/producer-cloudwatch-integ/KvsProducerSampleCloudwatch.cpp
@@ -109,6 +109,7 @@ INT32 main(INT32 argc, CHAR *argv[])
         canaryTypeStr = getCanaryStr(canaryType);
         CHK(STRCMP(canaryTypeStr, "") != 0, STATUS_INVALID_ARG);
         SNPRINTF(streamName, MAX_STREAM_NAME_LEN, "%s-canary-%s-%s", streamNamePrefix, canaryTypeStr, argv[3]);
+        DLOGD("streamName:%s\n", streamName);
         if ((region = getenv(DEFAULT_REGION_ENV_VAR)) == NULL) {
             region = (PCHAR) DEFAULT_AWS_REGION;
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When the log string is too big, using the same valist for vsprintf and vprintf leads to discrepancy in the cwLogFmtString length, sometime going over the 600 bytes of buffer size. Using a new valist for vsprintf ensures cwLogFmtString is always a clean slate. 

Use vsnprintf to be length safe

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
