### PR TITLE
Add format reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This repository contains a list of use cases with sample codes or high level des
 * [WebRTC C](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c)
 * [WebRTC JS](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js)
 
+Note: The structure for this repository, and examples contained within are defined [here](https://github.com/aws-samples/amazon-kinesis-video-streams-demos/pull/8).
+
 ## License
 
 This project is licensed under the Apache-2.0 License.


### PR DESCRIPTION
This is to make the format spec more visible.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
