### PR TITLE
Add signaling and ICE init delay metrics

### DIFF
--- a/webrtc-c/canary/src/CloudwatchMonitoring.cpp
+++ b/webrtc-c/canary/src/CloudwatchMonitoring.cpp
@@ -83,4 +83,17 @@ VOID CloudwatchMonitoring::pushSignalingInitDelay(UINT64 delay, StandardUnit uni
     this->push(datum);
 }
 
+VOID CloudwatchMonitoring::pushICEHolePunchingDelay(UINT64 delay, StandardUnit unit)
+{
+    MetricDatum datum;
+
+    datum.SetMetricName("ICEHolePunchingDelay");
+    datum.SetValue(delay);
+    datum.SetUnit(unit);
+
+    datum.AddDimensions(this->channelDimension);
+
+    this->push(datum);
+}
+
 } // namespace Canary

--- a/webrtc-c/canary/src/CloudwatchMonitoring.cpp
+++ b/webrtc-c/canary/src/CloudwatchMonitoring.cpp
@@ -70,4 +70,17 @@ VOID CloudwatchMonitoring::pushExitStatus(STATUS retStatus)
     this->push(datum);
 }
 
+VOID CloudwatchMonitoring::pushSignalingInitDelay(UINT64 delay, StandardUnit unit)
+{
+    MetricDatum datum;
+
+    datum.SetMetricName("SignalingInitDelay");
+    datum.SetValue(delay);
+    datum.SetUnit(unit);
+
+    datum.AddDimensions(this->channelDimension);
+
+    this->push(datum);
+}
+
 } // namespace Canary

--- a/webrtc-c/canary/src/CloudwatchMonitoring.h
+++ b/webrtc-c/canary/src/CloudwatchMonitoring.h
@@ -10,6 +10,7 @@ class CloudwatchMonitoring {
     VOID push(const MetricDatum&);
     VOID pushExitStatus(STATUS);
     VOID pushSignalingInitDelay(UINT64, StandardUnit);
+    VOID pushICEHolePunchingDelay(UINT64, StandardUnit);
 
   private:
     Dimension channelDimension;

--- a/webrtc-c/canary/src/CloudwatchMonitoring.h
+++ b/webrtc-c/canary/src/CloudwatchMonitoring.h
@@ -9,6 +9,7 @@ class CloudwatchMonitoring {
     VOID deinit();
     VOID push(const MetricDatum&);
     VOID pushExitStatus(STATUS);
+    VOID pushSignalingInitDelay(UINT64, StandardUnit);
 
   private:
     Dimension channelDimension;

--- a/webrtc-c/canary/src/Peer.cpp
+++ b/webrtc-c/canary/src/Peer.cpp
@@ -241,6 +241,15 @@ STATUS Peer::initPeerConnection()
         DLOGI("New connection state %u", newState);
 
         switch (newState) {
+            case RTC_PEER_CONNECTION_STATE_CONNECTING:
+                pPeer->iceHolePunchingStartTime = GETTIME();
+                break;
+            case RTC_PEER_CONNECTION_STATE_CONNECTED: {
+                auto duration = (GETTIME() - pPeer->iceHolePunchingStartTime) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+                DLOGI("ICE hole punching took %lu ms", duration);
+                Canary::Cloudwatch::getInstance().monitoring.pushICEHolePunchingDelay(duration, StandardUnit::Milliseconds);
+                break;
+            }
             case RTC_PEER_CONNECTION_STATE_FAILED:
                 // TODO: Replace this with a proper error code. Since there's no way to get the actual error code
                 // at this moment, STATUS_PEERCONNECTION_BASE seems to be the best error code.

--- a/webrtc-c/canary/src/Peer.h
+++ b/webrtc-c/canary/src/Peer.h
@@ -39,6 +39,9 @@ class Peer {
     std::vector<PRtcRtpTransceiver> videoTransceivers;
     STATUS status;
 
+    // metrics
+    UINT64 signalingStartTime;
+
     STATUS initSignaling();
     STATUS initRtcConfiguration();
     STATUS initPeerConnection();

--- a/webrtc-c/canary/src/Peer.h
+++ b/webrtc-c/canary/src/Peer.h
@@ -41,6 +41,7 @@ class Peer {
 
     // metrics
     UINT64 signalingStartTime;
+    UINT64 iceHolePunchingStartTime;
 
     STATUS initSignaling();
     STATUS initRtcConfiguration();


### PR DESCRIPTION
* Signaling init delay measures the time it takes from Signaling creation to connected
* ICE hole punching delay measures The delay from ICE_AGENT_STATE_CHECK_CONNECTION to ICE_AGENT_STATE_READY

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
