### PR TITLE
Downgrade cmake and remove client ID randomization

### DIFF
--- a/webrtc-c/canary/CMakeLists.txt
+++ b/webrtc-c/canary/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.10.2)
 project(KVSWebRTCCanary LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 11)
@@ -22,7 +22,17 @@ FetchContent_Declare(
   GIT_TAG        1.8.17
 )
 
-FetchContent_MakeAvailable(webrtc cloudwatch)
+FetchContent_GetProperties(webrtc)
+if(NOT webrtc_POPULATED)
+  FetchContent_Populate(webrtc)
+  add_subdirectory(${webrtc_SOURCE_DIR} ${webrtc_BINARY_DIR} EXCLUDE_FROM_ALL)
+endif()
+
+FetchContent_GetProperties(cloudwatch)
+if(NOT cloudwatch_POPULATED)
+  FetchContent_Populate(cloudwatch)
+  add_subdirectory(${cloudwatch_SOURCE_DIR} ${cloudwatch_BINARY_DIR} EXCLUDE_FROM_ALL)
+endif()
 
 # pass ca cert location to sdk
 add_definitions(-DKVS_CA_CERT_PATH="${CMAKE_SOURCE_DIR}/certs/cert.pem")

--- a/webrtc-c/canary/src/Config.cpp
+++ b/webrtc-c/canary/src/Config.cpp
@@ -66,7 +66,7 @@ STATUS Config::init(INT32 argc, PCHAR argv[], Canary::PConfig pConfig)
 
     CHK_STATUS(mustenv(CANARY_CHANNEL_NAME_ENV_VAR, &pConfig->pChannelName));
     CHK_STATUS(mustenv(CANARY_CLIENT_ID_ENV_VAR, &pClientId));
-    SPRINTF(pConfig->pClientId, "%s_%u", pClientId, RAND() % MAX_UINT32);
+    CHK_STATUS(mustenv(CANARY_CLIENT_ID_ENV_VAR, &pConfig->pClientId));
     CHK_STATUS(mustenvBool(CANARY_IS_MASTER_ENV_VAR, &pConfig->isMaster));
     /* This is ignored for master. Master can extract the info from offer. Viewer has to know if peer can trickle or
      * not ahead of time. */

--- a/webrtc-c/canary/src/Config.h
+++ b/webrtc-c/canary/src/Config.h
@@ -10,7 +10,7 @@ class Config {
     static STATUS init(INT32 argc, PCHAR argv[], PConfig);
 
     const CHAR* pChannelName;
-    CHAR pClientId[MAX_CLIENT_ID_STRING_LENGTH + 1];
+    const CHAR* pClientId;
     BOOL isMaster;
     BOOL trickleIce;
     BOOL useTurn;


### PR DESCRIPTION
Downgrade cmake version requirement to make the system requirement lower. And, remove client ID randomization as it's not needed anymore in single viewer scenario.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
