### PR TITLE
Fix failed to propagate error codes

### DIFF
--- a/webrtc-c/canary/src/Main.cpp
+++ b/webrtc-c/canary/src/Main.cpp
@@ -44,7 +44,12 @@ CleanUp:
         DLOGE("FOUND MEMORY LEAK");
     }
 
-    return (INT32) retStatus;
+    // https://www.gnu.org/software/libc/manual/html_node/Exit-Status.html
+    // We can only return with 0 - 127. Some platforms treat exit code >= 128
+    // to be a success code, which might give an unintended behaviour.
+    // Some platforms also treat 1 or 0 differently, so it's better to use
+    // EXIT_FAILURE and EXIT_SUCCESS macros for portability.
+    return STATUS_FAILED(retStatus) ? EXIT_FAILURE : EXIT_SUCCESS;
 }
 
 STATUS run(Canary::PConfig pConfig)


### PR DESCRIPTION
Since our error codes are greater than 127, some platforms treat these codes as "success" instead. This PR fixes this issue by mapping all of our error codes to `EXIT_FAILED`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
