### PR TITLE
Rtp stats and end to end metrics

### DIFF
--- a/webrtc-c/canary/src/CloudwatchMonitoring.cpp
+++ b/webrtc-c/canary/src/CloudwatchMonitoring.cpp
@@ -12,7 +12,6 @@ STATUS CloudwatchMonitoring::init()
 
     this->channelDimension.SetName("Channel");
     this->channelDimension.SetValue(pConfig->pChannelName);
-
     return retStatus;
 }
 
@@ -127,6 +126,78 @@ VOID CloudwatchMonitoring::pushICEHolePunchingDelay(UINT64 delay, StandardUnit u
     datum.AddDimensions(this->channelDimension);
 
     this->push(datum);
+}
+
+VOID CloudwatchMonitoring::pushOutboundRtpStats(Canary::POutgoingRTPMetricsContext pOutboundRtpStats)
+{
+    MetricDatum bytesDiscardedPercentageDatum, averageFramesRateDatum, nackRateDatum, retransmissionPercentDatum;
+
+    bytesDiscardedPercentageDatum.SetMetricName("PercentageFrameDiscarded");
+    bytesDiscardedPercentageDatum.SetValue(pOutboundRtpStats->framesPercentageDiscarded);
+    bytesDiscardedPercentageDatum.SetUnit(StandardUnit::Percent);
+    bytesDiscardedPercentageDatum.AddDimensions(this->channelDimension);
+    this->push(bytesDiscardedPercentageDatum);
+
+    averageFramesRateDatum.SetMetricName("FramesPerSecond");
+    averageFramesRateDatum.SetValue(pOutboundRtpStats->averageFramesSentPerSecond);
+    averageFramesRateDatum.SetUnit(StandardUnit::Count_Second);
+    averageFramesRateDatum.AddDimensions(this->channelDimension);
+    this->push(averageFramesRateDatum);
+
+    nackRateDatum.SetMetricName("NackPerSecond");
+    nackRateDatum.SetValue(pOutboundRtpStats->nacksPerSecond);
+    nackRateDatum.SetUnit(StandardUnit::Count_Second);
+    nackRateDatum.AddDimensions(this->channelDimension);
+    this->push(nackRateDatum);
+
+    retransmissionPercentDatum.SetMetricName("PercentageFramesRetransmitted");
+    retransmissionPercentDatum.SetValue(pOutboundRtpStats->retxBytesPercentage);
+    retransmissionPercentDatum.SetUnit(StandardUnit::Percent);
+    retransmissionPercentDatum.AddDimensions(this->channelDimension);
+    this->push(retransmissionPercentDatum);
+}
+
+VOID CloudwatchMonitoring::pushInboundRtpStats(Canary::PIncomingRTPMetricsContext pIncomingRtpStats)
+{
+    MetricDatum incomingBitrateDatum, incomingPacketRate, incomingFrameDropRateDatum;
+
+    incomingBitrateDatum.SetMetricName("IncomingBitRate");
+    incomingBitrateDatum.SetValue(pIncomingRtpStats->incomingBitRate);
+    incomingBitrateDatum.SetUnit(StandardUnit::Kilobits_Second);
+    incomingBitrateDatum.AddDimensions(this->channelDimension);
+    this->push(incomingBitrateDatum);
+
+    incomingPacketRate.SetMetricName("IncomingPacketsPerSecond");
+    incomingPacketRate.SetValue(pIncomingRtpStats->packetReceiveRate);
+    incomingPacketRate.SetUnit(StandardUnit::Count_Second);
+    incomingPacketRate.AddDimensions(this->channelDimension);
+    this->push(incomingPacketRate);
+
+    incomingFrameDropRateDatum.SetMetricName("IncomingFramesDroppedPerSecond");
+    incomingFrameDropRateDatum.SetValue(pIncomingRtpStats->framesDroppedPerSecond);
+    incomingFrameDropRateDatum.SetUnit(StandardUnit::Count_Second);
+    incomingFrameDropRateDatum.AddDimensions(this->channelDimension);
+    this->push(incomingFrameDropRateDatum);
+}
+
+VOID CloudwatchMonitoring::pushEndToEndMetrics(Canary::PEndToEndMetricsContext pEndToEndMetricsContext)
+{
+    MetricDatum endToEndLatencyDatum, sizeMatchDatum;
+
+    endToEndLatencyDatum.SetMetricName("EndToEndFrameLatency");
+    endToEndLatencyDatum.SetUnit(StandardUnit::Milliseconds);
+    endToEndLatencyDatum.AddDimensions(this->channelDimension);
+    endToEndLatencyDatum.SetValues(pEndToEndMetricsContext->frameLatency);
+    this->push(endToEndLatencyDatum);
+
+    sizeMatchDatum.SetMetricName("FrameSizeMatch");
+    sizeMatchDatum.SetUnit(StandardUnit::None);
+    sizeMatchDatum.AddDimensions(this->channelDimension);
+    sizeMatchDatum.SetValues(pEndToEndMetricsContext->sizeMatch);
+    this->push(sizeMatchDatum);
+
+    pEndToEndMetricsContext->frameLatency.clear();
+    pEndToEndMetricsContext->sizeMatch.clear();
 }
 
 } // namespace Canary

--- a/webrtc-c/canary/src/CloudwatchMonitoring.h
+++ b/webrtc-c/canary/src/CloudwatchMonitoring.h
@@ -13,6 +13,9 @@ class CloudwatchMonitoring {
     VOID pushSignalingInitDelay(UINT64, StandardUnit);
     VOID pushSignalingRoundtripLatency(UINT64, StandardUnit);
     VOID pushICEHolePunchingDelay(UINT64, StandardUnit);
+    VOID pushOutboundRtpStats(Canary::POutgoingRTPMetricsContext);
+    VOID pushInboundRtpStats(Canary::PIncomingRTPMetricsContext);
+    VOID pushEndToEndMetrics(Canary::PEndToEndMetricsContext);
 
   private:
     Dimension channelDimension;

--- a/webrtc-c/canary/src/Include.h
+++ b/webrtc-c/canary/src/Include.h
@@ -69,6 +69,13 @@
 #define STATUS_SIGNALING_CANARY_ANSWER_PAYLOAD_MISMATCH STATUS_SIGNALING_CANARY_BASE + 0x00000004
 #define STATUS_SIGNALING_CANARY_OFFER_PAYLOAD_MISMATCH  STATUS_SIGNALING_CANARY_BASE + 0x00000005
 
+#define CANARY_VIDEO_FRAMES_PATH (PCHAR) "./assets/h264SampleFrames/frame-%04d.h264"
+#define CANARY_AUDIO_FRAMES_PATH (PCHAR) "./assets/opusSampleFrames/sample-%03d.opus"
+
+#define METRICS_INVOCATION_PERIOD            (60 * HUNDREDS_OF_NANOS_IN_A_SECOND)
+#define END_TO_END_METRICS_INVOCATION_PERIOD (30 * HUNDREDS_OF_NANOS_IN_A_SECOND)
+#define CANARY_METADATA_SIZE                 (SIZEOF(UINT64) + SIZEOF(UINT32) + SIZEOF(UINT32))
+
 #include <aws/core/Aws.h>
 #include <aws/monitoring/CloudWatchClient.h>
 #include <aws/monitoring/model/PutMetricDataRequest.h>
@@ -90,6 +97,6 @@ using namespace std;
 
 #include "Config.h"
 #include "CloudwatchLogs.h"
+#include "Peer.h"
 #include "CloudwatchMonitoring.h"
 #include "Cloudwatch.h"
-#include "Peer.h"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Added RTP Stats (Incoming and outgoing)
- Added end to end metrics (end to end frame latency and data match). These metrics are more of a placeholder now because it does not work as expected. 

Todo:
- Frame size does not match from sender to receiver (there is a difference of 4 bytes end to end - need to investigate)
- End to end latency gives really large values at times because the data in pFrame metadata section is corrupted. Will investigate it

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
