### PR TITLE
Remove config reference in Peer

### DIFF
--- a/webrtc-c/canary/src/CanaryWebrtc.cpp
+++ b/webrtc-c/canary/src/CanaryWebrtc.cpp
@@ -87,8 +87,8 @@ STATUS run(Canary::PConfig pConfig)
 
         RtcMediaStreamTrack videoTrack, audioTrack;
 
-        Canary::Peer peer(pConfig, callbacks);
-        CHK_STATUS(peer.init());
+        Canary::Peer peer;
+        CHK_STATUS(peer.init(pConfig, callbacks));
         CHK_STATUS(peer.connect());
 
         std::thread videoThread(sendLocalFrames, &peer, MEDIA_STREAM_TRACK_KIND_VIDEO, "./assets/h264SampleFrames/frame-%04d.h264",

--- a/webrtc-c/canary/src/Peer.h
+++ b/webrtc-c/canary/src/Peer.h
@@ -11,9 +11,9 @@ class Peer {
         std::function<STATUS(PPeer)> onNewConnection;
     };
 
-    Peer(const Canary::PConfig, const Callbacks&);
+    Peer();
     ~Peer();
-    STATUS init();
+    STATUS init(const Canary::PConfig, const Callbacks&);
     STATUS shutdown();
     STATUS connect();
     STATUS addTransceiver(RtcMediaStreamTrack&);
@@ -21,8 +21,7 @@ class Peer {
     STATUS writeFrame(PFrame, MEDIA_STREAM_TRACK_KIND);
 
   private:
-    const Canary::PConfig pConfig;
-    const Callbacks callbacks;
+    Callbacks callbacks;
     PAwsCredentialProvider pAwsCredentialProvider;
     SIGNALING_CLIENT_HANDLE pSignalingClientHandle;
     std::recursive_mutex mutex;
@@ -37,14 +36,16 @@ class Peer {
     PRtcPeerConnection pPeerConnection;
     std::vector<PRtcRtpTransceiver> audioTransceivers;
     std::vector<PRtcRtpTransceiver> videoTransceivers;
+    BOOL isMaster;
+    BOOL trickleIce;
     STATUS status;
 
     // metrics
     UINT64 signalingStartTime;
     UINT64 iceHolePunchingStartTime;
 
-    STATUS initSignaling();
-    STATUS initRtcConfiguration();
+    STATUS initSignaling(const Canary::PConfig);
+    STATUS initRtcConfiguration(const Canary::PConfig);
     STATUS initPeerConnection();
     STATUS awaitIceGathering(PRtcSessionDescriptionInit);
     STATUS handleSignalingMsg(PReceivedSignalingMessage);


### PR DESCRIPTION
Removing config reference in Peer will help us in creating multiple peers easily.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
