### PR TITLE
Remove frameRate and bytesPerSecond from Peer

### DIFF
--- a/webrtc-c/canary/src/CanaryWebrtc.cpp
+++ b/webrtc-c/canary/src/CanaryWebrtc.cpp
@@ -120,7 +120,7 @@ STATUS run(Canary::PConfig pConfig)
 
         // Since the goal of the canary is to test robustness of the SDK, there is not an immediate need
         // to send audio frames as well. It can always be added in if needed in the future
-        std::thread videoThread(sendCustomFrames, &peer, MEDIA_STREAM_TRACK_KIND_VIDEO, peer.getDataRate(), peer.getFrameRate());
+        std::thread videoThread(sendCustomFrames, &peer, MEDIA_STREAM_TRACK_KIND_VIDEO, pConfig->bytesPerSecond, pConfig->frameRate);
         videoThread.join();
         CHK_STATUS(peer.shutdown());
     }

--- a/webrtc-c/canary/src/Peer.cpp
+++ b/webrtc-c/canary/src/Peer.cpp
@@ -543,14 +543,4 @@ CleanUp:
     return retStatus;
 }
 
-UINT64 Peer::getDataRate()
-{
-    return this->pConfig->bytesPerSecond;
-}
-
-UINT64 Peer::getFrameRate()
-{
-    return Peer::pConfig->frameRate;
-}
-
 } // namespace Canary

--- a/webrtc-c/canary/src/Peer.h
+++ b/webrtc-c/canary/src/Peer.h
@@ -19,8 +19,6 @@ class Peer {
     STATUS addTransceiver(RtcMediaStreamTrack&);
     STATUS addSupportedCodec(RTC_CODEC);
     STATUS writeFrame(PFrame, MEDIA_STREAM_TRACK_KIND);
-    UINT64 getDataRate();
-    UINT64 getFrameRate();
 
   private:
     Callbacks callbacks;


### PR DESCRIPTION
frameRate and bytesPerSecond are not needed in Peer, so removing them.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
