### PR TITLE
Delete signaling channel during shutdown

### DIFF
--- a/webrtc-c/canary/src/Peer.cpp
+++ b/webrtc-c/canary/src/Peer.cpp
@@ -313,6 +313,10 @@ STATUS Peer::shutdown()
         CHK_LOG_ERR(closePeerConnection(this->pPeerConnection));
     }
 
+    if (!this->isMaster && IS_VALID_SIGNALING_CLIENT_HANDLE(this->pSignalingClientHandle)) {
+        CHK_LOG_ERR(signalingClientDeleteSync(this->pSignalingClientHandle));
+    }
+
     return this->status;
 }
 


### PR DESCRIPTION
Since Canary can be used for load testing, it's common to use random channel names. So, it would be nice to delete these channels automatically during shutdown.

Related issue: https://github.com/aws-samples/amazon-kinesis-video-streams-demos/issues/47

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
