### PR TITLE
fix cmake minimum version required

### DIFF
--- a/webrtc-c/canary/CMakeLists.txt
+++ b/webrtc-c/canary/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.11)
 project(KVSWebRTCCanary LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 11)


### PR DESCRIPTION
FetchContent module is only available in CMake 3.11+

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
