### PR TITLE
Fix unmatched string type

### DIFF
--- a/webrtc-c/canary/src/CloudwatchLogs.cpp
+++ b/webrtc-c/canary/src/CloudwatchLogs.cpp
@@ -22,8 +22,8 @@ STATUS CloudwatchLogs::init()
     createLogStreamRequest.SetLogStreamName(pConfig->logStreamName.value);
     createLogStreamOutcome = this->client.CreateLogStream(createLogStreamRequest);
 
-    CHK_ERR(createLogStreamOutcome.IsSuccess(), STATUS_INVALID_OPERATION, "Failed to create \"%s\" log stream: %s", pConfig->logStreamName.value,
-            createLogStreamOutcome.GetError().GetMessage().c_str());
+    CHK_ERR(createLogStreamOutcome.IsSuccess(), STATUS_INVALID_OPERATION, "Failed to create \"%s\" log stream: %s",
+            pConfig->logStreamName.value.c_str(), createLogStreamOutcome.GetError().GetMessage().c_str());
 
 CleanUp:
 

--- a/webrtc-c/canary/src/Peer.cpp
+++ b/webrtc-c/canary/src/Peer.cpp
@@ -192,7 +192,7 @@ STATUS Peer::initRtcConfiguration(const Canary::PConfig pConfig)
     }
 
     // Set the  STUN server
-    SNPRINTF(pConfiguration->iceServers[0].urls, MAX_ICE_CONFIG_URI_LEN, KINESIS_VIDEO_STUN_URL, pConfig->region.value);
+    SNPRINTF(pConfiguration->iceServers[0].urls, MAX_ICE_CONFIG_URI_LEN, KINESIS_VIDEO_STUN_URL, pConfig->region.value.c_str());
 
     if (pConfig->useTurn.value) {
         // Set the URIs from the configuration


### PR DESCRIPTION
The bug should have been caught at compile time. But, gcc somehow allows
this but failed on clang.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
