### PR TITLE
Revert static build canary

### DIFF
--- a/webrtc-c/canary/CMakeLists.txt
+++ b/webrtc-c/canary/CMakeLists.txt
@@ -9,8 +9,6 @@ include(FetchContent)
 set(CUSTOM_MEMORY_MANAGEMENT OFF CACHE BOOL "Tell AWS SDK to not use custom memory management" FORCE)
 set(ENABLE_TESTING OFF CACHE BOOL "Disable building tests for AWS SDK" FORCE)
 set(BUILD_ONLY "monitoring;logs" CACHE STRING "Tell AWS SDK to only build monitoring and logs" FORCE)
-set(BUILD_SHARED_LIBS OFF CACHE BOOL "Enable static build for AWS SDK" FORCE)
-set(BUILD_STATIC_LIBS ON CACHE BOOL "Enable static build for KVS Webrtc SDK" FORCE)
 
 FetchContent_Declare(
   webrtc
@@ -48,7 +46,6 @@ include_directories(${webrtc_SOURCE_DIR}/open-source/include)
 link_directories(${webrtc_SOURCE_DIR}/open-source/lib)
 add_library(
   kvsWebrtcCanary
-  STATIC
   src/Config.cpp
   src/CloudwatchLogs.cpp
   src/CloudwatchMonitoring.cpp

--- a/webrtc-c/canary/jobs/runner.groovy
+++ b/webrtc-c/canary/jobs/runner.groovy
@@ -21,8 +21,7 @@ def buildProject() {
         mkdir -p build && 
         cd build && 
         cmake .. -DCMAKE_INSTALL_PREFIX="\$PWD" && 
-        make -j &&
-        rm -rf \$(ls | grep -v 'kvsWebrtc*')"""
+        make -j"""
 }
 
 def withRunnerWrapper(envs, fn) {


### PR DESCRIPTION
Static build causes a lot issues during configuration and compile times. The build fails on some platforms, and it hasn't been consistent.

The issue for high storage requirement is now tracked here, https://github.com/aws-samples/amazon-kinesis-video-streams-demos/issues/74.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
