### PR TITLE
Fix segfault

### DIFF
--- a/webrtc-c/canary/src/Peer.cpp
+++ b/webrtc-c/canary/src/Peer.cpp
@@ -670,15 +670,18 @@ STATUS Peer::publishStatsForCanary(RTC_STATS_TYPE statsType)
     this->canaryMetrics.requestedTypeOfStats = statsType;
     switch (statsType) {
         case RTC_STATS_TYPE_OUTBOUND_RTP:
-            CHK_LOG_ERR(::rtcPeerConnectionGetMetrics(this->pPeerConnection, this->videoTransceivers.back(), &this->canaryMetrics));
-            this->populateOutgoingRtpMetricsContext();
-            Canary::Cloudwatch::getInstance().monitoring.pushOutboundRtpStats(&this->canaryOutgoingRTPMetricsContext);
+            if(!this->videoTransceivers.empty()) {
+                CHK_LOG_ERR(::rtcPeerConnectionGetMetrics(this->pPeerConnection, this->videoTransceivers.back(), &this->canaryMetrics));
+                this->populateOutgoingRtpMetricsContext();
+                Canary::Cloudwatch::getInstance().monitoring.pushOutboundRtpStats(&this->canaryOutgoingRTPMetricsContext);
+            }
             break;
         case RTC_STATS_TYPE_INBOUND_RTP:
-            CHK_LOG_ERR(::rtcPeerConnectionGetMetrics(this->pPeerConnection, this->videoTransceivers.back(), &this->canaryMetrics));
-            this->populateIncomingRtpMetricsContext();
-            Canary::Cloudwatch::getInstance().monitoring.pushInboundRtpStats(&this->canaryIncomingRTPMetricsContext);
-
+            if(!this->videoTransceivers.empty()) {
+                CHK_LOG_ERR(::rtcPeerConnectionGetMetrics(this->pPeerConnection, this->videoTransceivers.back(), &this->canaryMetrics));
+                this->populateIncomingRtpMetricsContext();
+                Canary::Cloudwatch::getInstance().monitoring.pushInboundRtpStats(&this->canaryIncomingRTPMetricsContext);
+            }
             break;
         default:
             CHK(FALSE, STATUS_NOT_IMPLEMENTED);


### PR DESCRIPTION
*Issue #, if available:*
#77 

*Description of changes:*
- When the peer waits for an offer, the  stats threads are running with the assumption that the transceiver vectors have data in them. Without an offer, the vector is essentially empty, which when passed in `rtcPeerConnectionGetMetrics` leads to segfault because an empty vector is not treated as NULL. This PR fixes the issue by checking if the vector is empty before making the call.

Resolve #77 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
