### PR TITLE
Add canary label dimension

### DIFF
--- a/consumer-java/aws-kinesis-video-producer-sdk-canary-consumer/src/main/java/com/amazon/kinesis/video/canary/consumer/ProducerSdkCanaryConsumer.java
+++ b/consumer-java/aws-kinesis-video-producer-sdk-canary-consumer/src/main/java/com/amazon/kinesis/video/canary/consumer/ProducerSdkCanaryConsumer.java
@@ -29,11 +29,11 @@ public class ProducerSdkCanaryConsumer {
         String streamNamePrefix = System.getenv("CANARY_STREAM_NAME");
         String canaryType = System.getenv("CANARY_TYPE");
         String canaryFragmentSizeStr = System.getenv("FRAGMENT_SIZE_IN_BYTES");
+        String canaryLabel = System.getenv("CANARY_LABEL");
         String region = System.getenv("AWS_DEFAULT_REGION");
-        final String streamName = String.format("%s-canary-%s-%s", streamNamePrefix, canaryType,
-                    canaryFragmentSizeStr);
+        final String streamName = String.format("%s-%s-%s", streamNamePrefix, canaryType,
+                    canaryLabel);
         Integer canaryRunTime = Integer.parseInt(System.getenv("CANARY_DURATION_IN_SECONDS"));
-        
         log.info("Stream name {}", streamName);
 
         final SystemPropertiesCredentialsProvider credentialsProvider = new SystemPropertiesCredentialsProvider();
@@ -53,7 +53,7 @@ public class ProducerSdkCanaryConsumer {
                     @Override
                     public void process(InputStream inputStream, FragmentMetadataCallback fragmentMetadataCallback) throws MkvElementVisitException, IOException {
                         processWithFragmentEndCallbacks(inputStream, fragmentMetadataCallback,
-                                FrameVisitor.create(new CanaryFrameProcessor(amazonCloudWatch, streamName),
+                                FrameVisitor.create(new CanaryFrameProcessor(amazonCloudWatch, streamName, canaryLabel),
                                         Optional.of(new FragmentMetadataVisitor.BasicMkvTagProcessor())));
                     }
                 };

--- a/producer-c/producer-cloudwatch-integ/canary.json
+++ b/producer-c/producer-cloudwatch-integ/canary.json
@@ -1,8 +1,9 @@
 {
 	"CANARY_STREAM_NAME": "test", 
-	"CANARY_TYPE": "realtime", # Allowed values: realtime, offline
+	"CANARY_TYPE": "Realtime", # Allowed values: Realtime, Offline
 	"FRAGMENT_SIZE_IN_BYTES": "1048576", # Preferrably multiples of 1024 bytes
 	"CANARY_DURATION_IN_SECONDS": "60",
 	"CANARY_STORAGE_SIZE_IN_BYTES": "134217728", 
 	"CANARY_BUFFER_DURATION_IN_SECONDS": "120",
+	"CANARY_LABEL": "Longrun" # Allowed 20 characters
 }

--- a/producer-c/producer-cloudwatch-integ/init.sh
+++ b/producer-c/producer-cloudwatch-integ/init.sh
@@ -1,6 +1,7 @@
-export CANARY_STREAM_NAME=test 
-export CANARY_TYPE=realtime # Allowed values: realtime, offline
+export CANARY_STREAM_NAME=test
+export CANARY_TYPE=Realtime # Allowed values: Realtime, Offline
 export FRAGMENT_SIZE_IN_BYTES=1048576 # Preferrably multiples of 1024 bytes
 export CANARY_DURATION_IN_SECONDS=120
 export CANARY_STORAGE_SIZE_IN_BYTES=134217728 # in bytes
 export CANARY_BUFFER_DURATION_IN_SECONDS=120 #in seconds
+export CANARY_LABEL=Longrun #This will used as a dimension. Allowed 20 characters


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- In order to aggregate metrics based on suffix, it is necessary to push the metrics to a different dimension. This leads to pushing every metric to two different dimensions: One is `ProducerSDKCanaryStreamName` -> this includes metrics for every stream. The other is `ProducerSDKCanaryType` -> this includes an aggregated metric based on the type of canary being run. For example, if we run the SDK on different EC2 instances with stream name `test1-Longrun`, `test2-Longrun` and `test3-Longrun`, and want to get aggregated EndtoEnd frame latency, the aggregated metric emitted by all these streams would be available under `ProducerSDKCanaryType`->`Longrun`->` EndtoEndLatency`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
