### PR TITLE
Add scenario label to Jenkins scripts

### DIFF
--- a/webrtc-c/canary/jobs/orchestrator.groovy
+++ b/webrtc-c/canary/jobs/orchestrator.groovy
@@ -124,6 +124,7 @@ pipeline {
                                 string(name: 'MASTER_NODE_LABEL', value: "ec2-us-west-2"),
                                 string(name: 'VIEWER_NODE_LABEL', value: "ec2-us-west-2"),
                                 string(name: 'RUNNER_LABEL', value: "WebrtcPeriodic"),
+                                string(name: 'SCENARIO_LABEL', value: "WebrtcPeriodic"),
                             ],
                             wait: false
                         )
@@ -137,6 +138,7 @@ pipeline {
                                 string(name: 'MASTER_NODE_LABEL', value: "ec2-us-west-2"),
                                 string(name: 'VIEWER_NODE_LABEL', value: "ec2-us-west-2"),
                                 string(name: 'RUNNER_LABEL', value: "WebrtcLongRunning"),
+                                string(name: 'SCENARIO_LABEL', value: "WebrtcLongRunning"),
                             ],
                             wait: false
                         )
@@ -152,6 +154,7 @@ pipeline {
                                 //       because it's used to defined an agent
                                 string(name: 'VIEWER_NODE_LABEL', value: "ec2-us-west-2"),
                                 string(name: 'RUNNER_LABEL', value: "SignalingPeriodic"),
+                                string(name: 'SCENARIO_LABEL', value: "SignalingPeriodic"),
                             ],
                             wait: false
                         )
@@ -166,6 +169,7 @@ pipeline {
                                 //       because it's used to defined an agent
                                 string(name: 'VIEWER_NODE_LABEL', value: "ec2-us-west-2"),
                                 string(name: 'RUNNER_LABEL', value: "SignalingLongRunning"),
+                                string(name: 'SCENARIO_LABEL', value: "SignalingLongRunning"),
                             ],
                             wait: false
                         )

--- a/webrtc-c/canary/jobs/runner.groovy
+++ b/webrtc-c/canary/jobs/runner.groovy
@@ -50,6 +50,7 @@ def buildPeer(isMaster, params) {
       'CANARY_LOG_GROUP_NAME': params.LOG_GROUP_NAME,
       'CANARY_LOG_STREAM_NAME': "${params.RUNNER_LABEL}-${clientID}-${START_TIMESTAMP}",
       'CANARY_CHANNEL_NAME': "${env.JOB_NAME}-${params.RUNNER_LABEL}",
+      'CANARY_LABEL': params.SCENARIO_LABEL,
       'CANARY_CLIENT_ID': clientID,
       'CANARY_IS_MASTER': isMaster,
       'CANARY_DURATION_IN_SECONDS': params.DURATION_IN_SECONDS
@@ -83,6 +84,7 @@ def buildSignaling(params) {
       'CANARY_LOG_GROUP_NAME': params.LOG_GROUP_NAME,
       'CANARY_LOG_STREAM_NAME': "${params.RUNNER_LABEL}-Signaling-${START_TIMESTAMP}",
       'CANARY_CHANNEL_NAME': "${env.JOB_NAME}-${params.RUNNER_LABEL}",
+      'CANARY_LABEL': params.SCENARIO_LABEL,
       'CANARY_DURATION_IN_SECONDS': params.DURATION_IN_SECONDS
     ].collect({ k, v -> "${k}=${v}" })
     
@@ -113,6 +115,7 @@ pipeline {
         string(name: 'MASTER_NODE_LABEL')
         string(name: 'VIEWER_NODE_LABEL')
         string(name: 'RUNNER_LABEL')
+        string(name: 'SCENARIO_LABEL')
         string(name: 'DURATION_IN_SECONDS')
         string(name: 'MIN_RETRY_DELAY_IN_SECONDS')
         string(name: 'GIT_URL')
@@ -194,6 +197,7 @@ pipeline {
                       string(name: 'MASTER_NODE_LABEL', value: params.MASTER_NODE_LABEL),
                       string(name: 'VIEWER_NODE_LABEL', value: params.VIEWER_NODE_LABEL),
                       string(name: 'RUNNER_LABEL', value: params.RUNNER_LABEL),
+                      string(name: 'SCENARIO_LABEL', value: params.SCENARIO_LABEL),
                       string(name: 'DURATION_IN_SECONDS', value: params.DURATION_IN_SECONDS),
                       string(name: 'MIN_RETRY_DELAY_IN_SECONDS', value: params.MIN_RETRY_DELAY_IN_SECONDS),
                       string(name: 'GIT_URL', value: params.GIT_URL),


### PR DESCRIPTION
Currently, scenario label is the same with runner label. In the future, we will have more different sets of instances that are running with the same scenario. Scenario label is meant to be used to aggregate metrics at higher level.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
