### PR TITLE
Fix overshoot signaling init delay

### DIFF
--- a/webrtc-c/canary/src/Peer.h
+++ b/webrtc-c/canary/src/Peer.h
@@ -76,6 +76,7 @@ class Peer {
     std::atomic<BOOL> receivedAnswer;
     std::atomic<BOOL> foundPeerId;
     std::atomic<BOOL> recorded;
+    BOOL initializedSignaling = FALSE;
     std::string peerId;
     RtcConfiguration rtcConfiguration;
     PRtcPeerConnection pPeerConnection;


### PR DESCRIPTION
Since we handle auto refresh in signaling, it's possible to get to "CONNECTED" state again without going through "NEW" state. Thus, the timer won't be reset and cause an overshoot in the metrics.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
