### PR TITLE
Turn off async ICE server config retrieval

### DIFF
--- a/webrtc-c/canary/src/CanarySignaling.cpp
+++ b/webrtc-c/canary/src/CanarySignaling.cpp
@@ -323,7 +323,7 @@ STATUS run(Canary::PConfig pConfig)
     masterChannelInfo.channelRoleType = SIGNALING_CHANNEL_ROLE_TYPE_MASTER;
     masterChannelInfo.cachingPolicy = SIGNALING_API_CALL_CACHE_TYPE_FILE;
     masterChannelInfo.cachingPeriod = SIGNALING_API_CALL_CACHE_TTL_SENTINEL_VALUE;
-    masterChannelInfo.asyncIceServerConfig = TRUE;
+    masterChannelInfo.asyncIceServerConfig = FALSE;
     masterChannelInfo.retry = TRUE;
     masterChannelInfo.reconnect = TRUE;
     masterChannelInfo.pCertPath = (PCHAR) DEFAULT_KVS_CACERT_PATH;


### PR DESCRIPTION
This PR fixes `2020-10-08 18:43:27 ERROR   signalingConnectSync(): operation returned status code: 0x5200000e` error


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
