### PR TITLE
Reenable signaling canary

### DIFF
--- a/webrtc-c/canary/jobs/orchestrator.groovy
+++ b/webrtc-c/canary/jobs/orchestrator.groovy
@@ -143,7 +143,6 @@ pipeline {
                             wait: false
                         )
 
-                        /* TODO: Signaling canary is still unstable. Uncomment below when the software is stable.
                         build(
                             job: NEXT_AVAILABLE_RUNNER,
                             parameters: COMMON_PARAMS + [
@@ -173,7 +172,6 @@ pipeline {
                             ],
                             wait: false
                         )
-                        */
                     }
                 }
 


### PR DESCRIPTION
https://github.com/aws-samples/amazon-kinesis-video-streams-demos/pull/89 should fix the intermittent issue. Reenabling the signaling canary so that we can observe its stability.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
