### PR TITLE
Make exit logging consistent with webrtc canary

### DIFF
--- a/webrtc-c/canary/src/CanarySignaling.cpp
+++ b/webrtc-c/canary/src/CanarySignaling.cpp
@@ -397,7 +397,7 @@ CleanUp:
 
     STATUS combinedStatus = STATUS_FAILED(canarySessionInfo.exitStatus) ? canarySessionInfo.exitStatus : retStatus;
 
-    DLOGI("Exiting main with 0x%08x", combinedStatus);
+    DLOGI("Exiting with 0x%08x", combinedStatus);
     if (initialized) {
         Canary::Cloudwatch::getInstance().monitoring.pushExitStatus(combinedStatus);
     }


### PR DESCRIPTION
This allows easy filtering in Cloudwatch.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
