### PR TITLE
Add a unique identifier for config logging

### DIFF
--- a/webrtc-c/canary/src/Config.cpp
+++ b/webrtc-c/canary/src/Config.cpp
@@ -211,7 +211,7 @@ CleanUp:
 
 VOID Config::print()
 {
-    DLOGD("\n\n"
+    DLOGD("Applied configuration:\n\n"
           "\tLabel         : %s\n"
           "\tChannel Name  : %s\n"
           "\tRegion        : %s\n"


### PR DESCRIPTION
This allows us to easily filter config logging in Cloudwatch insight.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
