### PR TITLE
Fix log file name bug

### DIFF
--- a/producer-c/producer-cloudwatch-integ/canary/CanaryLogsUtils.cpp
+++ b/producer-c/producer-cloudwatch-integ/canary/CanaryLogsUtils.cpp
@@ -13,8 +13,6 @@ STATUS initializeCloudwatchLogger(PCloudwatchLogsObject pCloudwatchLogsObject)
     CHK(pCloudwatchLogsObject != NULL, STATUS_NULL_ARG);
     pCloudwatchLogsObject->canaryLogGroupRequest.SetLogGroupName(pCloudwatchLogsObject->logGroupName);
     pCloudwatchLogsObject->pCwl->CreateLogGroup(pCloudwatchLogsObject->canaryLogGroupRequest);
-    SNPRINTF(pCloudwatchLogsObject->logStreamName, ARRAY_SIZE(pCloudwatchLogsObject->logStreamName) - 1, "%s-%llu",
-             pCloudwatchLogsObject->logStreamName, GETTIME() / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 
     pCloudwatchLogsObject->canaryLogStreamRequest.SetLogStreamName(pCloudwatchLogsObject->logStreamName);
     pCloudwatchLogsObject->canaryLogStreamRequest.SetLogGroupName(pCloudwatchLogsObject->logGroupName);

--- a/producer-c/producer-cloudwatch-integ/canary/CanaryUtils.h
+++ b/producer-c/producer-cloudwatch-integ/canary/CanaryUtils.h
@@ -51,6 +51,7 @@ extern "C" {
 #define CANARY_TYPE_STR_LEN        10
 #define CANARY_STREAM_NAME_STR_LEN 200
 #define CANARY_LABEL_LEN           40
+#define MAX_LOG_FILE_NAME_LEN      300
 
 struct __CallbackStateMachine;
 struct __CallbacksProvider;
@@ -81,7 +82,7 @@ struct __CloudwatchLogsObject {
     Aws::Vector<Aws::CloudWatchLogs::Model::InputLogEvent> canaryInputLogEventVec;
     Aws::String token;
     CHAR logGroupName[MAX_STREAM_NAME_LEN + 1];
-    CHAR logStreamName[MAX_STREAM_NAME_LEN + 1];
+    CHAR logStreamName[MAX_LOG_FILE_NAME_LEN + 1];
 };
 typedef struct __CloudwatchLogsObject* PCloudwatchLogsObject;
 

--- a/producer-c/producer-cloudwatch-integ/canary/KvsProducerSampleCloudwatch.cpp
+++ b/producer-c/producer-cloudwatch-integ/canary/KvsProducerSampleCloudwatch.cpp
@@ -242,7 +242,7 @@ INT32 main(INT32 argc, CHAR* argv[])
         Aws::CloudWatchLogs::CloudWatchLogsClient cwl(clientConfiguration);
 
         STRCPY(cloudwatchLogsObject.logGroupName, "ProducerSDK");
-        SNPRINTF(cloudwatchLogsObject.logStreamName, MAX_STREAM_NAME_LEN + 5, "%s-log", streamName);
+        SNPRINTF(cloudwatchLogsObject.logStreamName, MAX_LOG_FILE_NAME_LEN, "%s-log-%llu", streamName, GETTIME() / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
         cloudwatchLogsObject.pCwl = &cwl;
         if ((retStatus = initializeCloudwatchLogger(&cloudwatchLogsObject)) != STATUS_SUCCESS) {
             DLOGW("Cloudwatch logger failed to be initialized with 0x%08x error code. Fallback to file logging", retStatus);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The log file name being generated was weird wherein only the timestamp was being used as part of the log stream name because of the way the log stream name was being populated. This PR fixes the issue to generate the expected log file name and relaxes the size of the name to provide more flexibility in the log stream naming.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
