### PR TITLE
Fix potential race condition in logger causing invalid log stream timestamps

### DIFF
--- a/producer-c/producer-cloudwatch-integ/canary/CanaryUtils.h
+++ b/producer-c/producer-cloudwatch-integ/canary/CanaryUtils.h
@@ -83,6 +83,7 @@ struct __CloudwatchLogsObject {
     Aws::String token;
     CHAR logGroupName[MAX_STREAM_NAME_LEN + 1];
     CHAR logStreamName[MAX_LOG_FILE_NAME_LEN + 1];
+    std::recursive_mutex mutex;
 };
 typedef struct __CloudwatchLogsObject* PCloudwatchLogsObject;
 

--- a/producer-c/producer-cloudwatch-integ/canary/KvsProducerSampleCloudwatch.cpp
+++ b/producer-c/producer-cloudwatch-integ/canary/KvsProducerSampleCloudwatch.cpp
@@ -290,6 +290,7 @@ INT32 main(INT32 argc, CHAR* argv[])
         // setup dummy frame
         frame.size = CANARY_METADATA_SIZE + config.fragmentSizeInBytes / DEFAULT_FPS_VALUE;
         frame.frameData = (PBYTE) MEMALLOC(frame.size);
+        CHK(frame.frameData != NULL, STATUS_NOT_ENOUGH_MEMORY);
         frame.version = FRAME_CURRENT_VERSION;
         frame.trackId = DEFAULT_VIDEO_TRACK_ID;
         frame.duration = 0;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Some logs might not get pushed if the log vector does not contain events in the appropriate timestamp order that might be caused due to a race condition. When different threads try to push logs into the events vector, a mutex would help ensuring a group of events are pushed into the vector in the appropriate order.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
