### PR TITLE
Reduce number of log files kept to reduce memory usage

### DIFF
--- a/producer-c/producer-cloudwatch-integ/jobs/canary_seed.groovy
+++ b/producer-c/producer-cloudwatch-integ/jobs/canary_seed.groovy
@@ -5,8 +5,8 @@ import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.*;
 
 WORKSPACE="producer-c/producer-cloudwatch-integ"
 GROOVY_SCRIPT_DIR="$WORKSPACE/jobs"
-DAYS_TO_KEEP_LOGS=7
-NUMBER_OF_LOGS=5
+DAYS_TO_KEEP_LOGS=2
+NUMBER_OF_LOGS=1
 MAX_EXECUTION_PER_NODE=1
 NAMESPACE="producer"
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Since the canaries push logs to cloudwatch, it is not necessary to maintain old logs for a long time since for long runs, logs bloat the memory usage on Jenkins leader. This PR reduces number of logs to be maintained to 1 and keeps it for 2 days only to provide a little relaxation and flexibility to check failed job logs within 2 days.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
