### PR TITLE
Keep current running job's logs only

### DIFF
--- a/canary/webrtc-c/jobs/seed.groovy
+++ b/canary/webrtc-c/jobs/seed.groovy
@@ -6,7 +6,7 @@ import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.*;
 NAMESPACE="webrtc-canary"
 WORKSPACE="canary/webrtc-c"
 JOBS_DIR="$WORKSPACE/jobs"
-NUM_LOGS=20
+NUM_LOGS=1
 
 void approveSignatures(ArrayList<String> signatures) {
     scriptApproval = ScriptApproval.get()


### PR DESCRIPTION
To reduce storage pressure on the master node, we should keep the number of logs to the minimum. Since we also publish the logs to Cloudwatch, we should still be able to go back in time if necessary.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
