### PR TITLE
Add intermittent producer to canary

### DIFF
--- a/canary/producer-c/canary/CanaryUtils.h
+++ b/canary/producer-c/canary/CanaryUtils.h
@@ -30,7 +30,10 @@ extern "C" {
 
 #define CANARY_FILE_LOGGING_BUFFER_SIZE (200 * 1024)
 #define CANARY_MAX_NUMBER_OF_LOG_FILES  10
-#define CANARY_APP_FILE_LOGGER          (PCHAR) "ENABLE_FILE_LOGGER"
+#define CANARY_APP_FILE_LOGGER       (PCHAR) "ENABLE_FILE_LOGGER"
+
+#define CANARY_INTERMITTENT_SCENARIO (PCHAR) "Intermittent"
+#define CANARY_CONTINUOUS_SCENARIO   (PCHAR) "Continuous"
 
 #define CANARY_TYPE_REALTIME           (PCHAR) "Realtime"
 #define CANARY_TYPE_OFFLINE            (PCHAR) "Offline"
@@ -41,8 +44,10 @@ extern "C" {
 #define CANARY_BUFFER_DURATION_ENV_VAR (PCHAR) "CANARY_BUFFER_DURATION_IN_SECONDS"
 #define CANARY_STORAGE_SIZE_ENV_VAR    (PCHAR) "CANARY_STORAGE_SIZE_IN_BYTES"
 #define CANARY_LABEL_ENV_VAR           (PCHAR) "CANARY_LABEL"
+#define CANARY_SCENARIO_ENV_VAR        (PCHAR) "CANARY_RUN_SCENARIO"
 
 #define CANARY_DEFAULT_STREAM_NAME         (PCHAR) "TestStream"
+#define CANARY_DEFAULT_SCENARIO_NAME       CANARY_CONTINUOUS_SCENARIO
 #define CANARY_DEFAULT_CANARY_TYPE         CANARY_TYPE_REALTIME
 #define CANARY_DEFAULT_DURATION_IN_SECONDS 60
 #define CANARY_DEFAULT_FRAGMENT_SIZE       (25 * 1024)
@@ -64,6 +69,7 @@ typedef struct {
     CHAR streamNamePrefix[CANARY_STREAM_NAME_STR_LEN + 1];
     CHAR canaryTypeStr[CANARY_TYPE_STR_LEN + 1];
     CHAR canaryLabel[CANARY_LABEL_LEN + 1];
+    CHAR canaryScenario[CANARY_LABEL_LEN + 1];
     UINT64 fragmentSizeInBytes;
     UINT64 canaryDuration;
     UINT64 bufferDuration;
@@ -98,6 +104,7 @@ struct __CanaryStreamCallbacks {
     StreamCallbacks streamCallbacks;
     PCHAR pStreamName;
     UINT64 totalNumberOfErrors;
+    BOOL aggregateMetrics;
     Aws::CloudWatch::CloudWatchClient* pCwClient;
     Aws::CloudWatch::Model::PutMetricDataRequest* cwRequest;
     Aws::CloudWatch::Model::Dimension dimensionPerStream;
@@ -123,6 +130,7 @@ VOID currentMemoryAllocation(PCanaryStreamCallbacks);
 VOID pushMetric(PCanaryStreamCallbacks pCanaryStreamCallback, Aws::CloudWatch::Model::MetricDatum&, Aws::CloudWatch::Model::StandardUnit, DOUBLE);
 STATUS publishErrorRate(STREAM_HANDLE, PCanaryStreamCallbacks, UINT64);
 STATUS pushStartUpLatency(PCanaryStreamCallbacks, DOUBLE);
+STATUS publishMetrics(STREAM_HANDLE, CLIENT_HANDLE, PCanaryStreamCallbacks);
 
 ////////////////////////////////////////////////////////////////////////
 // Cloudwatch logging related functions

--- a/canary/producer-c/init.sh
+++ b/canary/producer-c/init.sh
@@ -1,7 +1,8 @@
 export CANARY_STREAM_NAME=test
 export CANARY_TYPE=Realtime # Allowed values: Realtime, Offline
 export FRAGMENT_SIZE_IN_BYTES=1048576 # Preferrably multiples of 1024 bytes
-export CANARY_DURATION_IN_SECONDS=120
+export CANARY_DURATION_IN_SECONDS=1800
 export CANARY_STORAGE_SIZE_IN_BYTES=134217728 # in bytes
 export CANARY_BUFFER_DURATION_IN_SECONDS=120 #in seconds
-export CANARY_LABEL=Longrun #This will used as a dimension. Allowed 20 characters
+export CANARY_LABEL=Intermittent #This will used as a dimension. Allowed 20 characters
+export CANARY_RUN_SCENARIO=Intermittent # Allowed values: Intermittent, Continuous

--- a/canary/producer-c/jobs/orchestrator.groovy
+++ b/canary/producer-c/jobs/orchestrator.groovy
@@ -24,8 +24,7 @@ COMMON_PARAMS = [
 
 def getJobLastBuildTimestamp(job) {
     def timestamp = 0
-    def lastBuild = job.getLastBuild()
-
+    
     if (lastBuild != null) {
         timestamp = lastBuild.getTimeInMillis()
     }
@@ -126,6 +125,7 @@ pipeline {
                                 string(name: 'RUNNER_LABEL', value: "Longrun"),
                                 string(name: 'FRAGMENT_SIZE_IN_BYTES', value: FRAGMENT_SIZE_IN_BYTES.toString()),
                                 string(name: 'AWS_DEFAULT_REGION', value: AWS_DEFAULT_REGION),
+                                string(name: 'CANARY_RUN_SCENARIO', value: "Continuous"),
                             ],
                             wait: false
                         )
@@ -139,6 +139,21 @@ pipeline {
                                 string(name: 'RUNNER_LABEL', value: "Periodic"),
                                 string(name: 'FRAGMENT_SIZE_IN_BYTES', value: FRAGMENT_SIZE_IN_BYTES.toString()),
                                 string(name: 'AWS_DEFAULT_REGION', value: AWS_DEFAULT_REGION),
+                                string(name: 'CANARY_RUN_SCENARIO', value: "Continuous"),
+                            ],
+                            wait: false
+                        )
+                        build(
+                            job: NEXT_AVAILABLE_RUNNER,
+                            parameters: COMMON_PARAMS + [
+                                string(name: 'CANARY_DURATION_IN_SECONDS', value: LONG_RUN_DURATION_IN_SECONDS.toString()),
+                                string(name: 'PRODUCER_NODE_LABEL', value: "producer-uw2"),
+                                string(name: 'CONSUMER_NODE_LABEL', value: "consumer-uw2"),
+                                string(name: 'CANARY_TYPE', value: "Realtime"),
+                                string(name: 'RUNNER_LABEL', value: "Intermittent"),
+                                string(name: 'FRAGMENT_SIZE_IN_BYTES', value: FRAGMENT_SIZE_IN_BYTES.toString()),
+                                string(name: 'AWS_DEFAULT_REGION', value: AWS_DEFAULT_REGION),
+                                string(name: 'CANARY_RUN_SCENARIO', value: "Intermittent"),
                             ],
                             wait: false
                         )

--- a/canary/producer-c/jobs/runner.groovy
+++ b/canary/producer-c/jobs/runner.groovy
@@ -64,6 +64,7 @@ def runClient(isProducer, params) {
         'FRAGMENT_SIZE_IN_BYTES' : params.FRAGMENT_SIZE_IN_BYTES,
         'CANARY_DURATION_IN_SECONDS': params.CANARY_DURATION_IN_SECONDS,
         'AWS_DEFAULT_REGION': params.AWS_DEFAULT_REGION,
+        'CANARY_RUN_SCENARIO': "${params.CANARY_RUN_SCENARIO}",
     ].collect({k,v -> "${k}=${v}" })
 
     // TODO: get the branch and version from orchestrator
@@ -146,6 +147,7 @@ pipeline {
         string(name: 'CANARY_DURATION_IN_SECONDS')
         string(name: 'MIN_RETRY_DELAY_IN_SECONDS')
         string(name: 'AWS_DEFAULT_REGION')
+        string(name: 'CANARY_RUN_SCENARIO')
         booleanParam(name: 'FIRST_ITERATION', defaultValue: true)
     }
 
@@ -171,7 +173,11 @@ pipeline {
                     }
                     steps {
                         script {
-                            runClient(false, params)
+
+                            // Only run consumer if it is not intermittent scenario
+                            if(params.CANARY_RUN_SCENARIO == "Continuous") {
+                                    runClient(false, params)
+                            }
                         }
                     }                
                 }
@@ -205,6 +211,7 @@ pipeline {
                                 string(name: 'MIN_RETRY_DELAY_IN_SECONDS', value: params.MIN_RETRY_DELAY_IN_SECONDS),
                                 string(name: 'AWS_DEFAULT_REGION', value: params.AWS_DEFAULT_REGION),
                                 string(name: 'RUNNER_LABEL', value: params.RUNNER_LABEL),
+                                string(name: 'CANARY_RUN_SCENARIO', value: params.CANARY_RUN_SCENARIO),
                                 booleanParam(name: 'FIRST_ITERATION', value: false)
                             ],
                     wait: false


### PR DESCRIPTION
*Issue #, if available:*
#132 
*Description of changes:*

- Adding intermittent producer to canaries
- Modified metric push logic to not contribute to aggregated in intermittent scenario since intermittent produces missing data points while sleep which will cause alarms
- Modified jenkins scripts to not run the consumer application in case of intermittent producer since the consumer application needs to be adapted to this scenario if end to end metrics are to be captured.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
