### PR TITLE
Fix high latency shoot ups for intermittent producer canary

### DIFF
--- a/canary/producer-c/CMake/Dependencies/libkvsProducerC-CMakeLists.txt
+++ b/canary/producer-c/CMake/Dependencies/libkvsProducerC-CMakeLists.txt
@@ -6,7 +6,7 @@ include(ExternalProject)
 
 ExternalProject_Add(libkvsProducerC-download
     GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-producer-c.git
-    GIT_TAG           17d875fc54e7378f1c1483854990582fb7aa4336
+    GIT_TAG           154a779868c75f1b29199f70e3eb10d166b0ffaa
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
     CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX} -DBUILD_COMMON_LWS=ON -DBUILD_COMMON_CURL=ON -DBUILD_DEPENDENCIES=TRUE -DOPEN_SRC_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}
     BUILD_ALWAYS      TRUE

--- a/canary/producer-c/canary/KvsProducerSampleCloudwatch.cpp
+++ b/canary/producer-c/canary/KvsProducerSampleCloudwatch.cpp
@@ -370,6 +370,7 @@ INT32 main(INT32 argc, CHAR* argv[])
                 THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_SECOND / DEFAULT_FPS_VALUE);
             }
             else {
+                canaryStreamRecordFragmentEndSendTime(pCanaryStreamCallbacks, lastKeyFrameTimestamp, frame.presentationTs);
                 DLOGD("Last frame type put before stopping: %s", (frame.flags == FRAME_FLAG_KEY_FRAME ? "Key Frame" : "Non key frame"));
                 UINT64 sleepTime = ((RAND() % 10) + 1) * HUNDREDS_OF_NANOS_IN_A_MINUTE;
                 DLOGD("Intermittent sleep time is set to: %" PRIu64 " minutes", sleepTime / HUNDREDS_OF_NANOS_IN_A_MINUTE);


### PR DESCRIPTION
*Issue #, if available:*
#136 

*Description of changes:*
- Previously, we recorded end fragment time only on every key frame. However, in intermittent scenario, it is possible we stop the `putFrame` operation on a non key frame which leads to the fragment's key frame timestamp to be added to the map after the sleep time. Since the SDK sends a persisted Ack after closing the fragment, the map might not have the recorded key frame time when the ack arrives, leading to a random value being used [here](https://github.com/aws-samples/amazon-kinesis-video-streams-demos/blob/9559671c83a14a9247e479f516b50c6018af427b/canary/producer-c/canary/CanaryStreamUtils.cpp#L184), that inturn leads to bizarre values for Ack latency. This change fixes it by recording the key frame timestamp right before `sleep`.

- This PR also updates producer C to most recent commit.

Resolves #136 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
