### PR TITLE
Fix bug in jenkins job for producer

### DIFF
--- a/canary/producer-c/CMake/Dependencies/libcppsdk-CMakeLists.txt
+++ b/canary/producer-c/CMake/Dependencies/libcppsdk-CMakeLists.txt
@@ -8,10 +8,12 @@ ExternalProject_Add(libawscpp-download
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
     LIST_SEPARATOR 	  "|"
     CMAKE_ARGS		  -DCUSTOM_MEMORY_MANAGEMENT=OFF 
-                	  -DBUILD_DEPS=ON 
-                	  -DBUILD_SHARED_LIBS=OFF 
-                	  -DBUILD_ONLY=monitoring|logs
-                      -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}
-    BUILD_ALWAYS      TRUE
+                    -DENABLE_TESTING=OFF 
+                    -DAUTORUN_UNIT_TESTS=OFF 
+                    -DBUILD_DEPS=ON 
+                    -DBUILD_SHARED_LIBS=OFF 
+                    -DBUILD_ONLY=monitoring|logs
+                    -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}
+    BUILD_ALWAYS      0
     TEST_COMMAND      ""
 )

--- a/canary/producer-c/jobs/runner.groovy
+++ b/canary/producer-c/jobs/runner.groovy
@@ -21,7 +21,7 @@ def buildProducer() {
     mkdir -p build
     cd build && 
     cmake .. && 
-    make 
+    make -j4
   """
 }
 
@@ -31,7 +31,7 @@ def buildConsumer(envs) {
         PATH="$JAVA_HOME/bin:$PATH"
         export PATH="$M2_HOME/bin:$PATH"
         cd $WORKSPACE/canary/consumer-java
-        make
+        make -j4
     '''
   }
 }
@@ -89,17 +89,15 @@ def runClient(isProducer, params) {
 
     RUNNING_NODES++
     echo "Number of running nodes: ${RUNNING_NODES}"
-    if(params.FIRST_ITERATION) {
-        if(isProducer) {
-            buildProducer()
-        }
-        else {
-            // This is to make sure that the consumer does not make RUNNING_NODES
-            // zero before producer build starts. Should handle this in a better
-            // way
-            sleep consumerStartUpDelay
-            buildConsumer(envs)   
-        }        
+    if(isProducer) {
+        buildProducer()
+    }
+    else {
+        // This is to make sure that the consumer does not make RUNNING_NODES
+        // zero before producer build starts. Should handle this in a better
+        // way
+        sleep consumerStartUpDelay
+        buildConsumer(envs)   
     }
 
     RUNNING_NODES--


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In some scenarios, when a new run of a job is started (when FIRST_ITERATION is FALSE), it can start in another node which does not have all the build artifacts available, this causes an unstable build on jenkins. While this mostly does not affect metrics being emitted and has not affected any runs so far, it is capable of not running the applications because the sample executables are not available which can cause missing metrics.

In order to also reduce the build time in subsequent runs, we should compile cpp sdk which disabling running of the heavy unit/integ tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
