### PR TITLE
Pass configured region to WebRTC lib in GST plugin

### DIFF
--- a/gst/gst-kvs-plugin/src/KvsWebRtc.c
+++ b/gst/gst-kvs-plugin/src/KvsWebRtc.c
@@ -240,6 +240,7 @@ STATUS initKinesisVideoWebRtc(PGstKvsPlugin pGstPlugin)
     MEMSET(&pGstPlugin->kvsContext.signalingClientInfo, 0x00, SIZEOF(SignalingClientInfo));
     MEMSET(&pGstPlugin->kvsContext.signalingClientCallbacks, 0x00, SIZEOF(SignalingClientCallbacks));
 
+    pGstPlugin->kvsContext.channelInfo.pRegion = pGstPlugin->pRegion;
     pGstPlugin->kvsContext.channelInfo.version = CHANNEL_INFO_CURRENT_VERSION;
     pGstPlugin->kvsContext.channelInfo.pChannelName = pGstPlugin->gstParams.channelName;
     pGstPlugin->kvsContext.channelInfo.pKmsKeyId = NULL;


### PR DESCRIPTION
*Issue #, if available: #152*

*Description of changes:*
This passes the region given to the GST plugin via the `aws-region` property to the WebRTC library. This ensure that when a region is specified to the GST plugin that both the Video Stream and Signaling Channel are created in the requested region.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
