### PR TITLE
Set audio codec appropriately in WebRTC

### DIFF
--- a/gst/gst-kvs-plugin/README.md
+++ b/gst/gst-kvs-plugin/README.md
@@ -29,8 +29,10 @@ To build the library and the provided samples run make in the build directory yo
 
 A very basic example of a GStreamer pipeline to run on Mac
 
+
 ```sh
-gst-launch-1.0 -e autovideosrc !  vtenc_h264_hw max-keyframe-interval=30 bitrate=500 ! kvsplugin stream-name=ScaryTestStream channel-name="ScaryTestChannel" log-level=3
+export GTS_PLUGIN_PATH=`pwd`/build
+gst-launch-1.0 autovideosrc !  vtenc_h264_hw max-keyframe-interval=30 bitrate=500 ! kvsplugin stream-name=ScaryTestStream channel-name="ScaryTestChannel" log-level=3
 ```
 
 This will launch the default camera video stream only with hardware-accelerated encoder with 1sec fragments and up-to 500Kbps stream. Use or create a stream by the given name and a channel by its name. Will use INFO level logging.

--- a/gst/gst-kvs-plugin/src/GstPlugin.h
+++ b/gst/gst-kvs-plugin/src/GstPlugin.h
@@ -166,6 +166,8 @@ struct __GstParams {
     gchar* kmsKeyId;
     STREAMING_TYPE streamingType;
     gchar* contentType;
+    gchar* audioContentType;
+    gchar* videoContentType;
     guint maxLatencyInSeconds;
     guint fragmentDurationInMillis;
     guint timeCodeScaleInMillis;

--- a/gst/gst-kvs-plugin/src/KvsProducer.c
+++ b/gst/gst-kvs-plugin/src/KvsProducer.c
@@ -133,13 +133,17 @@ STATUS initTrackData(PGstKvsPlugin pGstKvsPlugin)
 
     switch (pGstKvsPlugin->mediaType) {
         case GST_PLUGIN_MEDIA_TYPE_AUDIO_VIDEO:
+            pGstKvsPlugin->gstParams.audioContentType = g_strdup(audioContentType);
+            pGstKvsPlugin->gstParams.videoContentType = g_strdup(videoContentType);
             pGstKvsPlugin->gstParams.contentType = g_strjoin(",", videoContentType, audioContentType, NULL);
             break;
         case GST_PLUGIN_MEDIA_TYPE_AUDIO_ONLY:
+            pGstKvsPlugin->gstParams.audioContentType = g_strdup(audioContentType);
             pGstKvsPlugin->gstParams.contentType = g_strdup(audioContentType);
             break;
         case GST_PLUGIN_MEDIA_TYPE_VIDEO_ONLY:
             pGstKvsPlugin->gstParams.contentType = g_strdup(videoContentType);
+            pGstKvsPlugin->gstParams.videoContentType = g_strdup(videoContentType);
             break;
     }
 


### PR DESCRIPTION
*Issue #, if available:*
#159 
*Description of changes:*

Audio codec set in the pipeline was not parsed appropriately in WebRTC, resulting in any type of audio to be set Opus codec ID by default. This change ensures the appropriate ID is set based on what is supplied in the pipeline.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
