### PR TITLE
Use cmake3 from yum

### DIFF
--- a/producer-cpp/docker-amazonlinux/Dockerfile
+++ b/producer-cpp/docker-amazonlinux/Dockerfile
@@ -8,7 +8,7 @@ RUN yum install -y \
 	automake  \
 	bison \
 	bzip2 \
-	cmake \
+	cmake3 \
 	curl \
 	diffutils \
 	flex \
@@ -28,19 +28,12 @@ RUN yum install -y \
 	pkgconfig \
 	vim \
 	wget \
-	xz && \
-	wget https://cmake.org/files/v3.12/cmake-3.12.3.tar.gz && \
-    tar zxvf cmake-3.* && \
-    rm cmake-3.12.3.tar.gz && \
-    cd cmake-3.12.3/ && \
-    ./bootstrap && \
-    make -j4 && \
-    make install
+	xz
 
 WORKDIR /opt/
 RUN git clone https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp.git
 WORKDIR /opt/amazon-kinesis-video-streams-producer-sdk-cpp/build/
-RUN cmake .. -DBUILD_GSTREAMER_PLUGIN=ON -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON && \
+RUN cmake3 .. -DBUILD_GSTREAMER_PLUGIN=ON -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON && \
     make 
 
 ENV LD_LIBRARY_PATH=/opt/amazon-kinesis-video-streams-producer-sdk-cpp/open-source/local/lib


### PR DESCRIPTION
Fixes #187 

This switches to use `cmake3` from `yum` instead of installing it manually to simplify things and reduce image size


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
