### PR TITLE
Use correct API to get signaling retry count to publish to cloud watch

### DIFF
--- a/canary/webrtc-c/src/Peer.cpp
+++ b/canary/webrtc-c/src/Peer.cpp
@@ -734,10 +734,10 @@ STATUS Peer::publishRetryCount()
     signalingClientMetrics.version = SIGNALING_CLIENT_METRICS_CURRENT_VERSION;
     CHK_STATUS(signalingClientGetMetrics(signalingClientHandle, &signalingClientMetrics));
 
-    Canary::Cloudwatch::getInstance().monitoring.pushRetryCount(signalingClientMetrics.apiCallRetryCount);
+    Canary::Cloudwatch::getInstance().monitoring.pushRetryCount(signalingClientMetrics.signalingClientStats.apiCallRetryCount);
 
 CleanUp:
-    if (retStatus != SUCCESS) {
+    if (retStatus != STATUS_SUCCESS) {
         DLOGE("Error 0x%08x while getting signaling client metrics to publish signaling API retry count", retStatus);
     }
 

--- a/canary/webrtc-c/src/Peer.cpp
+++ b/canary/webrtc-c/src/Peer.cpp
@@ -729,8 +729,18 @@ STATUS Peer::publishEndToEndMetrics()
 STATUS Peer::publishRetryCount()
 {
     STATUS retStatus = STATUS_SUCCESS;
-    Canary::Cloudwatch::getInstance().monitoring.pushRetryCount(this->clientInfo.stateMachineRetryCountReadOnly);
+    SignalingClientMetrics signalingClientMetrics;
+
+    signalingClientMetrics.version = SIGNALING_CLIENT_METRICS_CURRENT_VERSION;
+    CHK_STATUS(signalingClientGetMetrics(signalingClientHandle, &signalingClientMetrics));
+
+    Canary::Cloudwatch::getInstance().monitoring.pushRetryCount(signalingClientMetrics.apiCallRetryCount);
+
 CleanUp:
+    if (retStatus != SUCCESS) {
+        DLOGE("Error 0x%08x while getting signaling client metrics to publish signaling API retry count", retStatus);
+    }
+
     return retStatus;
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Use correct API to get signaling retry count to publish to cloud watch

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
