### PR TITLE
Kvssink canary cpp demos

### DIFF
--- a/canary/producer-cpp/CMakeLists.txt
+++ b/canary/producer-cpp/CMakeLists.txt
@@ -9,21 +9,21 @@ endif()
 
 project(KinesisVideoProducerCloudwatch LANGUAGES C CXX)
 
-set(BUILD_GSTREAMER_PLUGIN ON CACHE BOOL "Tell KVS Producer CPP SDK to build with GStreamer Plugin" FORCE)
+#set(BUILD_GSTREAMER_PLUGIN ON CACHE BOOL "Tell KVS Producer CPP SDK to build with GStreamer Plugin" FORCE)
 set(CUSTOM_MEMORY_MANAGEMENT OFF CACHE BOOL "Tell AWS SDK to not use custom memory management" FORCE)
 set(ENABLE_TESTING OFF CACHE BOOL "Disable building tests for AWS SDK" FORCE)
 set(BUILD_ONLY "monitoring;logs" CACHE STRING "Tell AWS SDK to only build monitoring and logs" FORCE)
 
 FetchContent_Declare(
-  producercpp
-  GIT_REPOSITORY https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp.git
-  GIT_TAG        a90ad686ea11a56b2fe54e4fbdfcf3ceb846703d
+        producercpp
+        GIT_REPOSITORY https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp.git
+        GIT_TAG        kvssink-canary-cpp
 )
 
 FetchContent_Declare(
-  cloudwatch
-  GIT_REPOSITORY https://github.com/aws/aws-sdk-cpp
-  GIT_TAG        1.9.67
+        cloudwatch
+        GIT_REPOSITORY https://github.com/aws/aws-sdk-cpp
+        GIT_TAG        1.10.9
 )
 
 FetchContent_GetProperties(producercpp)
@@ -64,13 +64,17 @@ link_directories(${GST_APP_LIBRARY_DIRS})
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 add_executable(producer_cpp_canary
-            ${CANARY_SOURCE_FILES})
+        ${CANARY_SOURCE_FILES})
 
 
+
+file(GLOB GST_PLUGIN_SOURCE_FILES "${producercpp_SOURCE_DIR}/src/gstreamer/*.cpp" "${producercpp_SOURCE_DIR}/src/gstreamer/Util/*.cpp")
+add_library(gstkvssink MODULE ${GST_PLUGIN_SOURCE_FILES})
+target_link_libraries(gstkvssink PRIVATE ${GST_APP_LIBRARIES} KinesisVideoProducer)
 
 target_link_libraries(producer_cpp_canary ${GST_APP_LIBRARIES} KinesisVideoProducer
-                        aws-cpp-sdk-core
-                        aws-cpp-sdk-monitoring
-                        aws-cpp-sdk-logs)
+        aws-cpp-sdk-core
+        aws-cpp-sdk-monitoring
+        aws-cpp-sdk-logs)
 
 file(COPY "${producercpp_SOURCE_DIR}/kvs_log_configuration" DESTINATION ${CMAKE_CURRENT_SOURCE_DIR})

--- a/canary/producer-cpp/cert_setup.sh
+++ b/canary/producer-cpp/cert_setup.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
 prefix=$1
-thingName="${prefix}_thing"
-thingTypeName="${prefix}_thing_type"
-iotPolicyName="${prefix}_policy"
-kvsPolicyName="${prefix}_policy"
-iotRoleName="${prefix}_role"
-iotRoleAlias="${prefix}_role_alias"
-iotCert="${prefix}_certificate.pem"
-iotPublicKey="${prefix}_public.key"
-iotPrivateKey="${prefix}_private.key"
+thingName="sink_${prefix}_thing"
+thingTypeName="sink_${prefix}_thing_type"
+iotPolicyName="sink_${prefix}_policy"
+kvsPolicyName="sink_${prefix}_policy"
+iotRoleName="sink_${prefix}_role"
+iotRoleAlias="sink_${prefix}_role_alias"
+iotCert="sink_${prefix}_certificate.pem"
+iotPublicKey="sink_${prefix}_public.key"
+iotPrivateKey="sink_${prefix}_private.key"
 
 # Create the certificate to which you must attach the policy for IoT that you created above.
 aws --profile default  iot create-keys-and-certificate --set-as-active --certificate-pem-outfile $iotCert --public-key-outfile $iotPublicKey --private-key-outfile $iotPrivateKey > certificate

--- a/canary/producer-cpp/cert_setup.sh
+++ b/canary/producer-cpp/cert_setup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+prefix=$1
+thingName="${prefix}_thing"
+thingTypeName="${prefix}_thing_type"
+iotPolicyName="${prefix}_policy"
+kvsPolicyName="${prefix}_policy"
+iotRoleName="${prefix}_role"
+iotRoleAlias="${prefix}_role_alias"
+iotCert="${prefix}_certificate.pem"
+iotPublicKey="${prefix}_public.key"
+iotPrivateKey="${prefix}_private.key"
+
+# Create the certificate to which you must attach the policy for IoT that you created above.
+aws --profile default  iot create-keys-and-certificate --set-as-active --certificate-pem-outfile $iotCert --public-key-outfile $iotPublicKey --private-key-outfile $iotPrivateKey > certificate
+# Attach the policy for IoT (KvsCameraIoTPolicy created above) to this certificate.
+aws --profile default  iot attach-policy --policy-name $iotPolicyName --target $(jq --raw-output '.certificateArn' certificate)
+# Attach your IoT thing (kvs_example_camera_stream) to the certificate you just created:
+aws --profile default  iot attach-thing-principal --thing-name $thingName --principal $(jq --raw-output '.certificateArn' certificate)
+# In order to authorize requests through the IoT credentials provider, you need the IoT credentials endpoint which is unique to your AWS account ID. You can use the following command to get the IoT credentials endpoint.
+aws --profile default  iot describe-endpoint --endpoint-type iot:CredentialProvider --output text > iot-credential-provider.txt
+# In addition to the X.509 cerficiate created above, you must also have a CA certificate to establish trust with the back-end service through TLS. You can get the CA certificate using the following command:
+curl 'https://www.amazontrust.com/repository/SFSRootCAG2.pem' --output cacert.pem

--- a/canary/producer-cpp/generate-iot-credentials.sh
+++ b/canary/producer-cpp/generate-iot-credentials.sh
@@ -4,15 +4,15 @@
 # https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/how-iot.html
 
 prefix=$1
-thingName="${prefix}_thing"
-thingTypeName="${prefix}_thing_type"
-iotPolicyName="${prefix}_policy"
-kvsPolicyName="${prefix}_policy"
-iotRoleName="${prefix}_role"
-iotRoleAlias="${prefix}_role_alias"
-iotCert="${prefix}_certificate.pem"
-iotPublicKey="${prefix}_public.key"
-iotPrivateKey="${prefix}_private.key"
+thingName="sink_${prefix}_thing"
+thingTypeName="sink_${prefix}_thing_type"
+iotPolicyName="sink_${prefix}_policy"
+kvsPolicyName="sink_${prefix}_policy"
+iotRoleName="sink_${prefix}_role"
+iotRoleAlias="sink_${prefix}_role_alias"
+iotCert="sink_${prefix}_certificate.pem"
+iotPublicKey="sink_${prefix}_public.key"
+iotPrivateKey="sink_${prefix}_private.key"
 
 # Step 1: Create an IoT Thing Type and an IoT Thing
 # The following example command creates a thing type $thingTypeName

--- a/canary/producer-cpp/generate-iot-credentials.sh
+++ b/canary/producer-cpp/generate-iot-credentials.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# You need to setup your aws cli first, because this script is based on aws cli.
+# You can use this script to setup environment variables in the shell which samples run on.
+# https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/how-iot.html
+
+prefix=$1
+thingName="${prefix}_thing"
+thingTypeName="${prefix}_thing_type"
+iotPolicyName="${prefix}_policy"
+kvsPolicyName="${prefix}_policy"
+iotRoleName="${prefix}_role"
+iotRoleAlias="${prefix}_role_alias"
+iotCert="${prefix}_certificate.pem"
+iotPublicKey="${prefix}_public.key"
+iotPrivateKey="${prefix}_private.key"
+
+# Step 1: Create an IoT Thing Type and an IoT Thing
+# The following example command creates a thing type $thingTypeName
+aws --profile default  iot create-thing-type --thing-type-name $thingTypeName > iot-thing-type.json
+# And this example command creates the $thingName thing of the $thingTypeName thing type:
+aws --profile default  iot create-thing --thing-name $thingName --thing-type-name $thingTypeName > iot-thing.json
+
+# Step 2: Create an IAM Role to be Assumed by IoT
+# You can use the following trust policy JSON for the iam-policy-document.json:
+cat > iam-policy-document.json <<EOF
+{
+   "Version":"2012-10-17",
+   "Statement":[
+      {
+     "Effect":"Allow",
+     "Principal":{
+        "Service":"credentials.iot.amazonaws.com"
+    },
+     "Action":"sts:AssumeRole"
+ }
+   ]
+}
+EOF
+
+# Create an IAM role.
+aws --profile default  iam create-role --role-name $iotRoleName --assume-role-policy-document 'file://iam-policy-document.json' > iam-role.json
+
+# You can use the following IAM policy JSON for the iam-permission-document.json:
+cat > iam-permission-document.json <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "kinesisvideo:ListStreams",
+                "kinesisvideo:CreateStream"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "kinesisvideo:DescribeStream",
+                "kinesisvideo:PutMedia",
+                "kinesisvideo:TagStream",
+                "kinesisvideo:GetDataEndpoint"
+            ],
+            "Resource": "arn:aws:kinesisvideo:*:*:stream/\${credentials-iot:ThingName}/*"
+        }
+    ]
+}
+EOF
+
+# Next, you must attach a permissions policy to the IAM role you created above.
+aws --profile default iam put-role-policy --role-name $iotRoleName --policy-name $kvsPolicyName --policy-document 'file://iam-permission-document.json'
+# Next, create a Role Alias for your IAM Role
+aws --profile default  iot create-role-alias --role-alias $iotRoleAlias --role-arn $(jq --raw-output '.Role.Arn' iam-role.json) --credential-duration-seconds 3600 > iot-role-alias.json
+
+# You can use the following command to create the iot-policy-document.json document JSON:
+cat > iot-policy-document.json << EOF
+{
+   "Version":"2012-10-17",
+   "Statement":[
+      {
+     "Effect":"Allow",
+     "Action":[
+        "iot:Connect"
+     ],
+     "Resource":"*"
+ },
+      {
+     "Effect":"Allow",
+     "Action":[
+        "iot:AssumeRoleWithCertificate"
+     ],
+     "Resource":"$(jq --raw-output '.roleAliasArn' iot-role-alias.json)"
+ }
+   ]
+}
+EOF
+
+# Now you can create the policy that will enable IoT to assume role with the certificate (once it is attached) using the role alias.
+aws --profile default iot create-policy --policy-name $iotPolicyName --policy-document 'file://iot-policy-document.json'

--- a/canary/producer-cpp/kvs_log_configuration
+++ b/canary/producer-cpp/kvs_log_configuration
@@ -1,0 +1,16 @@
+log4cplus.rootLogger=DEBUG, KvsConsoleAppender, KvsFileAppender
+
+#log4cplus.logger.MemoryCheck=TRACE, KvsConsoleAppender
+
+#KvsConsoleAppender:
+log4cplus.appender.KvsConsoleAppender=log4cplus::ConsoleAppender
+log4cplus.appender.KvsConsoleAppender.layout=log4cplus::PatternLayout
+log4cplus.appender.KvsConsoleAppender.layout.ConversionPattern=[%-5p] [%d{%d-%m-%Y %H:%M:%S:%Q %Z}] %m%n
+
+#KvsFileAppender
+log4cplus.appender.KvsFileAppender=log4cplus::DailyRollingFileAppender
+log4cplus.appender.KvsFileAppender.File=./log/kvs.log
+log4cplus.appender.KvsFileAppender.Schedule=HOURLY
+log4cplus.appender.KvsFileAppender.CreateDirs=true
+log4cplus.appender.KvsFileAppender.layout=log4cplus::PatternLayout
+log4cplus.appender.KvsFileAppender.layout.ConversionPattern=[%-5p] [%d{%d-%m-%Y %H:%M:%S:%Q %Z}] %m%n

--- a/canary/producer-cpp/src/Canary.cpp
+++ b/canary/producer-cpp/src/Canary.cpp
@@ -411,36 +411,10 @@ bool put_frame(CustomData *cusData, VOID *data, size_t len, const nanoseconds &p
     return ret;
 }
 
-void determine_credentials(GstElement *kvssink, CustomData *data) {
-
-    char const *iot_credential_endpoint;
-    char const *cert_path;
-    char const *private_key_path;
-    char const *role_alias;
-    char const *ca_cert_path;
-    char const *credential_path;
-    if (nullptr != (iot_credential_endpoint = getenv("IOT_GET_CREDENTIAL_ENDPOINT")) &&
-        nullptr != (cert_path = getenv("CERT_PATH")) &&
-        nullptr != (private_key_path = getenv("PRIVATE_KEY_PATH")) &&
-        nullptr != (role_alias = getenv("ROLE_ALIAS")) &&
-        nullptr != (ca_cert_path = getenv("CA_CERT_PATH"))) {
-        // set the IoT Credentials if provided in envvar
-        GstStructure *iot_credentials =  gst_structure_new(
-                "iot-certificate",
-                "iot-thing-name", G_TYPE_STRING, data->streamName,
-                "endpoint", G_TYPE_STRING, iot_credential_endpoint,
-                "cert-path", G_TYPE_STRING, cert_path,
-                "key-path", G_TYPE_STRING, private_key_path,
-                "ca-path", G_TYPE_STRING, ca_cert_path,
-                "role-aliases", G_TYPE_STRING, role_alias, NULL);
-
-        g_object_set(G_OBJECT (kvssink), "iot-certificate", iot_credentials, NULL);
-        gst_structure_free(iot_credentials);
-        // kvssink will search for long term credentials in envvar automatically so no need to include here
-        // if no long credentials or IoT credentials provided will look for credential file as last resort
-    } else if(nullptr != (credential_path = getenv("AWS_CREDENTIAL_PATH"))){
-        g_object_set(G_OBJECT (kvssink), "credential-path", credential_path, NULL);
-    }
+//Test function to check signal connect
+static VOID streamCheck(GstElement *kvssink, CustomData *customData){
+    CustomData *data = reinterpret_cast<CustomData *>(customData);
+    LOG_DEBUG("stream check received handler");
 }
 
 // This function is called when an error message is posted on the bus
@@ -477,7 +451,7 @@ int gstreamer_test_source_init(CustomData *data, GstElement *pipeline) {
 
     // configure kvssink
     g_object_set(G_OBJECT (kvssink), "stream-name", data->streamName, "storage-size", 128, NULL);
-//    determine_credentials(kvssink, data);
+    g_signal_connect(G_OBJECT(kvssink), "persisted-ack", (GCallback) streamCheck, data);
 
     // define and configure video filter, we only want the specified format to pass to the sink
     // ("caps" is short for "capabilities")

--- a/canary/producer-cpp/src/CanaryConfig.h
+++ b/canary/producer-cpp/src/CanaryConfig.h
@@ -8,7 +8,6 @@
 #include <Logger.h>
 
 #include "com/amazonaws/kinesis/video/cproducer/Include.h"
-#include "CanaryCallbackProvider.h"
 
 using namespace std;
 

--- a/canary/producer-cpp/src/CustomData.h
+++ b/canary/producer-cpp/src/CustomData.h
@@ -20,6 +20,7 @@
 #include "CanaryConfig.h"
 #include "CanaryLogs.h"
 
+typedef struct _KvsSinkMetric KvsSinkMetric;
 typedef enum _StreamSource {
 TEST_SOURCE,
 FILE_SOURCE,
@@ -81,4 +82,12 @@ public:
     uint64_t firstPts;
 
     CustomData();
+};
+
+struct _KvsSinkMetric {
+    _KvsSinkMetric():
+            framePTS(0) {}
+    KinesisVideoStreamMetrics streamMetrics = KinesisVideoStreamMetrics();
+    KinesisVideoProducerMetrics clientMetrics = KinesisVideoProducerMetrics();
+    UINT64 framePTS;
 };

--- a/canary/producer-cpp/src/Include.h
+++ b/canary/producer-cpp/src/Include.h
@@ -2,6 +2,7 @@
 
 #include <gst/gst.h>
 #include <gst/app/gstappsink.h>
+#include <gstreamer/gstkvssink.h>
 #include <string.h>
 #include <chrono>
 #include <Logger.h>

--- a/canary/producer-cpp/src/Include.h
+++ b/canary/producer-cpp/src/Include.h
@@ -22,7 +22,6 @@
 #include <aws/logs/model/DeleteLogStreamRequest.h>
 #include <aws/logs/model/DescribeLogStreamsRequest.h>
 
-#include "CanaryCallbackProvider.h"
 #include "CanaryConfig.h"
 #include "CanaryLogs.h"
 #include "CustomData.h"

--- a/canary/producer-cpp/src/Include.h
+++ b/canary/producer-cpp/src/Include.h
@@ -2,7 +2,6 @@
 
 #include <gst/gst.h>
 #include <gst/app/gstappsink.h>
-#include <gstreamer/gstkvssink.h>
 #include <string.h>
 #include <chrono>
 #include <Logger.h>


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Migrated demos canary producer cpp to kvssink from appsink.

*Changes:*
1. The kvssink is build as module in demos
2. Connected gstreamer signal emitted in kvssink producer sdk cpp whenever fragment acks and put frame invoked via gstreamer connect in demos canary producer cpp
3. Publishing cloudwatch metrics, using the parameter passed via gstreamer signal emit in producer sdk cpp
4. IOT credentials setup scripts to generated IOT cred and setup certificate for access

*Testing:*
Tested with both AWS credentials and IOT credentials, the cloudwatch metrics are visible in the AWS account cloudwatch who's credentials are used(In this case my personal account) and the default video media play in AWS account Kinesis Video Stream for the stream created while running the application

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
