### PR TITLE
Update kvsplugin build dependencies (to fix issue #279)

### DIFF
--- a/gst/gst-kvs-plugin/CMakeLists.txt
+++ b/gst/gst-kvs-plugin/CMakeLists.txt
@@ -16,15 +16,13 @@ include(FetchContent)
 FetchContent_Declare(
         webrtc
         GIT_REPOSITORY https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c
-        #GIT_TAG v1.5.0
-        GIT_TAG 8b8b2bdf064f6cb2b6495339d31efc3518b12eb9
+        GIT_TAG v1.7.3
 )
 
 FetchContent_Declare(
         cproducer
         GIT_REPOSITORY https://github.com/awslabs/amazon-kinesis-video-streams-producer-c
-        #GIT_TAG v1.1.0
-        GIT_TAG 58e1c6a1cb191f947d904784503b506e04525682
+        GIT_TAG v1.4.0
 )
 
 FetchContent_GetProperties(webrtc)


### PR DESCRIPTION
Issue #279

*Description of changes:*

Updates the build dependencies of libgstkvsplugin.so, that were leading to a broken build. 

Based on the fix proposed in: https://github.com/aws-samples/amazon-kinesis-video-streams-demos/issues/241 (closed, but not fixed) and PR https://github.com/aws-samples/amazon-kinesis-video-streams-demos/pull/245 (not merged)

Tested with:
``` 
mkdir -p amazon-kinesis-video-streams-demos/gst/gst-kvs-plugin/build
cd amazon-kinesis-video-streams-demos/gst/gst-kvs-plugin/build 
cmake -DBUILD_GSTREAMER_PLUGIN=TRUE ..
make
export GST_PLUGIN_PATH=`pwd`
gst-inspect-1.0 kvsplugin
```

Resulting in a correct gst plugin:
``` 
gst-inspect-1.0 kvsplugin
Factory Details:
  Rank                     primary + 10 (266)
  Long-name                KVS Plugin
  Klass                    Sink/Video/Network
  Description              GStreamer AWS KVS plugin
  Author                   AWS KVS <kinesis-video-support@amazon.com>

Plugin Details:
  Name                     kvsplugin
  Description              GStreamer AWS KVS plugin
  Filename                 /host/tests/amazon-kinesis-video-streams-demos/gst/gst-kvs-plugin/build/libgstkvsplugin.so
  Version                  1.0
  License                  Proprietary
  Source module            kvspluginpackage
  Binary package           GStreamer
  Origin URL               http://gstreamer.net/

GObject
 +----GInitiallyUnowned
       +----GstObject
             +----GstElement
                   +----GstKvsPlugin

....
```