### PR TITLE
Use multi-stage build to reduce image size

### DIFF
--- a/producer-cpp/docker-rtsp/Dockerfile
+++ b/producer-cpp/docker-rtsp/Dockerfile
@@ -9,18 +9,12 @@ RUN apt-get upgrade && \
     g++ \
     git \
     gstreamer1.0-plugins-base-apps \
-    gstreamer1.0-plugins-bad \
-    gstreamer1.0-plugins-good \
-    gstreamer1.0-plugins-ugly \
     libgstreamer1.0-dev \
     libgstreamer-plugins-base1.0-dev \
     m4 \
     maven \
     openjdk-8-jdk \
-    python2.7 \
     pkg-config \
-    vim \
-    wget  \
     xz-utils && \
     rm -rf /var/lib/apt/lists/* && \
     cd /opt/
@@ -29,7 +23,7 @@ RUN apt-get upgrade && \
 WORKDIR /opt/
 RUN git clone https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp.git
 WORKDIR /opt/amazon-kinesis-video-streams-producer-sdk-cpp/build/
-RUN cmake .. -DBUILD_GSTREAMER_PLUGIN=ON &&\
+RUN cmake .. -DBUILD_GSTREAMER_PLUGIN=ON && \
     make
 
 
@@ -37,11 +31,10 @@ FROM ubuntu:18.04
 
 RUN apt update && \
     apt install -y \
-    gstreamer1.0-plugins-base-apps \
     gstreamer1.0-plugins-bad \
     gstreamer1.0-plugins-good \
     gstreamer1.0-plugins-ugly \
-    openjdk-8-jre &&\
+    openjdk-8-jre && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /opt/amazon-kinesis-video-streams-producer-sdk-cpp /opt/amazon-kinesis-video-streams-producer-sdk-cpp

--- a/producer-cpp/docker-rtsp/Dockerfile
+++ b/producer-cpp/docker-rtsp/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:18.04 AS builder
 
 RUN apt-get upgrade && \
     apt-get update && \
@@ -31,6 +31,22 @@ RUN git clone https://github.com/awslabs/amazon-kinesis-video-streams-producer-s
 WORKDIR /opt/amazon-kinesis-video-streams-producer-sdk-cpp/build/
 RUN cmake .. -DBUILD_GSTREAMER_PLUGIN=ON &&\
     make
+
+
+FROM ubuntu:18.04
+
+RUN apt update && \
+    apt install -y \
+    gstreamer1.0-plugins-base-apps \
+    gstreamer1.0-plugins-bad \
+    gstreamer1.0-plugins-good \
+    gstreamer1.0-plugins-ugly \
+    openjdk-8-jre &&\
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /opt/amazon-kinesis-video-streams-producer-sdk-cpp /opt/amazon-kinesis-video-streams-producer-sdk-cpp
+
+WORKDIR /opt/amazon-kinesis-video-streams-producer-sdk-cpp/build/
 
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64/
 ENV LD_LIBRARY_PATH=/opt/amazon-kinesis-video-streams-producer-sdk-cpp/open-source/local/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Use [multi-stage build](https://docs.docker.com/build/building/multi-stage/) to reduce the image size. Reducing image size from 1.2GiB to 653MiB.

```
REPOSITORY        TAG       IMAGE ID        CREATED           PLATFORM       SIZE         BLOB SIZE
rtspdockertest    latest    d34fbf828bfb    24 hours ago      linux/arm64    1.2 GiB      494.1 MiB   // original
rtsp-slim         latest    b82b0ef5ba7b    10 minutes ago    linux/arm64    653.1 MiB    292.4 MiB   // reduced
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
