### PR TITLE
Fix Canary ReadMe Typos, Add Producer Cpp Canary to Home ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This repository contains a list of use cases with sample codes or high level des
 * [WebRTC JS](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js)
 * Canary
   * [Producer C](/canary/producer-c)
+  * [Producer CPP](/canary/producer-cpp)
   * [Consumer Java](/canary/consumer-java)
   * [Webrtc C](/canary/webrtc-c)
 * GStreamer

--- a/canary/consumer-java/README.md
+++ b/canary/consumer-java/README.md
@@ -1,7 +1,7 @@
 # Java parser library based Consumer application
 
 ## Introduction
-The application is a simple frame parser that is developed to run with the producer SDK to get some end to end metrics and emit to cloudwatch. The app can be used to run long term canaries and is a demo to introduce parser library based application integration with cloudwatch services. 
+The application is a simple frame parser that is developed to run with the producer SDK to get some end to end metrics and emit them to Cloudwatch. The app can be used to run long term canaries and is a demo to introduce parser library based application integration with cloudwatch services. 
 
 ## Requirements
 
@@ -10,7 +10,7 @@ The application is a simple frame parser that is developed to run with the produ
 3. `make`
 
 ## Build
-To download run the following command:
+To download, run the following command:
 
 `git clone https://github.com/aws-samples/amazon-kinesis-video-streams-demos.git`
 
@@ -18,11 +18,11 @@ Move to the directory containing the `pom.xml` file:
 
 `cd canary/consumer-java`
 
-Next, run `make`. This will take of the build steps and generate the necessary classpath string of dependencies
+Next, run `make`. This will take care of the build steps and generate the necessary classpath string of dependencies
 
 ## Running the application
 
-Since this is developed keeping in mind the end to end scenario with producer SDK, the following environment variables need to be exported to generate the same stream name that is generated in the producer SDK. Take a look at [this](https://github.com/aws-samples/amazon-kinesis-video-streams-demos/blob/master/canary/producer-c/init.sh) to check out the exports. Additionally, you also need to export the following:
+Since this is developed keeping in mind the end to end scenario with the producer SDK, the following environment variables need to be exported to generate the same stream name that is generated in the producer SDK. Take a look at [this](https://github.com/aws-samples/amazon-kinesis-video-streams-demos/blob/master/canary/producer-c/init.sh) to check out the exports. Additionally, you also need to export the following:
 
 1. `AWS_ACCESS_KEY_ID` 
 2. `AWS_SECRET_ACCESS_KEY`
@@ -41,20 +41,20 @@ When run in an end to end scenario, the following metrics are collected and can 
 
 | Metric	                 | Frequency	    | Unit         | Description	           
 |--------------------|:-------------:|:-------------:|:-------------|
-| FrameDataMatches                       | Every frame receive at consumer  | None         | The frame packet received the consumer contains a checksum, which is compared with the checksum calculated at the consumer with the received packet. If equal, 1.0 is pushed as a metric, else 0.0 is pushed
+| FrameDataMatches                       | Every frame received at consumer  | None         | The frame packet received by the consumer contains a checksum, which is compared with the checksum calculated at the consumer with the received packet. If equal, 1.0 is pushed as a metric, else 0.0 is pushed
 | FrameSizeMatch	                     | Every frame receive at consumer| None           | The size of the frame received with the packet is compared to the size calculated on the received frame at the consumer. If equal, 1.0 is emitted, else 0.0 is emitted
-| FrameDropped	                         | Every frame receive at consumer| None           | The metric indicates if any frames were dropped. The frame index is compared index of previous frame received and if the index does not indicate lastFrameIndex + 1, this metric is set to 1.0
+| FrameDropped	                         | Every frame receive at consumer| None           | The metric indicates if any frames were dropped. The frame index is compared to the index of previous frame received and if the index does not indicate lastFrameIndex + 1, this metric is set to 1.0
 | FrameTimeMatchesProducerTimestamp	     | Every frame receive at consumer| None           | The metric indicates if frameTimestampInsideData matches sum of pts and frame timecode. If true, this metric is set to 1.0, else it is set to 0.0
 
 ## Cloudwatch
 
 Every metric is available in two dimensions:
-1. Per stream: This will be available under `KinesisVideoSDKCanary->ProducerSDKCanaryStreamName` in cloudwatch console
-2. Aggregated over all streams based on `canary-type`. `canary-type` is set by running `export CANARY_LABEL=value`. This will be available under `KinesisVideoSDKCanary->ProducerSDKCanaryType` in cloudwatch console
+1. Per stream: This will be available under `KinesisVideoSDKCanary->ProducerSDKCanaryStreamName` in the cloudwatch console
+2. Aggregated over all streams based on `canary-type`. `canary-type` is set by running `export CANARY_LABEL=value`. This will be available under `KinesisVideoSDKCanary->ProducerSDKCanaryType` in the cloudwatch console
 
 ## References
 
-1. To checkout how this is integrated with the producer SDK, look [here](https://github.com/aws-samples/amazon-kinesis-video-streams-demos/tree/master/canary/producer-c)
+1. To check out how this is integrated with the producer SDK, look [here](https://github.com/aws-samples/amazon-kinesis-video-streams-demos/tree/master/canary/producer-c)
 2. [Parser library](https://github.com/aws/amazon-kinesis-video-streams-parser-library)
 
 

--- a/canary/producer-c/README.md
+++ b/canary/producer-c/README.md
@@ -17,36 +17,36 @@ Note 2: Currently, this demo is tested on Linux and MacOS.
 4. `make`
 
 ## Build
-To download run the following command:
+To download, run the following command:
 
 `git clone https://github.com/aws-samples/amazon-kinesis-video-streams-demos.git`
 
 Configure
-Create a build directory in the newly checked out repository, and execute CMake from it.
+Create a build directory in the newly checked out repository and execute CMake from it.
 
 1. `mkdir -p amazon-kinesis-video-streams-demos/canary/producer-c/build` 
 2. `cd amazon-kinesis-video-streams-demos/canary/producer-c/build`
 3. `cmake ..`
 
-The file installs the C Producer SDK libraries, PIC libraries for you and CPP SDK components for you.
+The file installs the C Producer SDK libraries, PIC libraries, and CPP SDK components for you.
 
-NOTE: This project requires setting up of AWS SDK CPP Libraries. The specific components being used are:
+NOTE: This project requires the setting up of AWS SDK CPP Libraries. The specific components being used are:
 1. `events`
 2. `monitoring`
 3. `logs`
 
 ## Running the application
 
-The demo comprises of a simple sample that uses custom constructed frames to capture certain metrics and performance parameters of the C Producer SDK and PIC. To run the sample:
+The demo comprises of a simple sample that uses custom-constructed frames to capture certain metrics and performance parameters of the C Producer SDK and PIC. To run the sample:
 
 `./kvsProducerSampleCloudwatch <path-to-config-file>`, or
 `./kvsProducerSampleCloudwatch`	
 
-Note that if config file is provided and environment variables are exported, JSON file is used to configure the canary app
+Note that if a config file is provided and environment variables are exported, a JSON file is used to configure the canary app
 
 The application uses a JSON file or environment variables to parse some parameters that can be controlled by the application. It is necessary to provide the absolute path to the JSON file to run the application. A sample config file is provided [here](https://github.com/aws-samples/amazon-kinesis-video-streams-demos/tree/master/canary/producer-c). If using environment variables, take a look at the [sample shell script](https://github.com/aws-samples/amazon-kinesis-video-streams-demos/tree/master/canary/producer-c).
 
-On running the application, the metrics are geenrated and posted in the `KinesisVideoSDKCanary` namespace with stream name format:  `<stream-name-prefix>-<Realtime/Offline>-<canary-type>`, where `canary-type` is signifies the type of run of the application, for example, `periodic`, `longrun`, etc.
+On running the application, the metrics are generated and posted in the `KinesisVideoSDKCanary` namespace with stream name format:  `<stream-name-prefix>-<Realtime/Offline>-<canary-type>`, where `canary-type` signifies the type of run of the application, for example, `periodic`, `longrun`, etc.
 
 ## Metrics being collected currently
 
@@ -95,7 +95,7 @@ Required Script Signature Approvals:
 
 #### Seeding
 
-Seeding is a meta job that its sole job is to bootstrap other jobs, orchestrator and runners. 
+Seeding is a meta job whose sole job is to bootstrap other jobs, orchestrator and runners. 
 When there's a new change to the seed or the other jobs that were created from the seed, the change will automatically propagate to the other jobs. 
 
 The concept is very similar to [AWS CloudFormation](https://aws.amazon.com/cloudformation/)
@@ -105,7 +105,7 @@ Seed script can be found [here](https://github.com/aws-samples/amazon-kinesis-vi
 
 #### Orchestration
 
-Orchestration is a process of permuting a set of the canary configuration and delegate the works to the runner. The permutation can be ranging from streaming duration, bitrate, device types, regions, etc.
+Orchestration is a process of permuting a set of the canary configurations and delegating the works to the runner. The permutation can be ranging from streaming duration, bitrate, device types, regions, etc.
 
 ![orchestrator](./docs/orchestrator.png)
 

--- a/canary/webrtc-c/README.md
+++ b/canary/webrtc-c/README.md
@@ -3,11 +3,11 @@
 ## Build
 
 ### Download
-To download run the following command:
+To download, run the following command:
 
 `git clone https://github.com/aws-samples/amazon-kinesis-video-streams-demos.git`
 
-You will also need to install `pkg-config` and `CMake` and a build enviroment
+You will also need to install `pkg-config` and `CMake` and a build environment
 
 ### Configure
 Create a build directory in the newly checked out repository, and execute CMake from it.
@@ -15,7 +15,7 @@ Create a build directory in the newly checked out repository, and execute CMake 
 `mkdir -p amazon-kinesis-video-streams-demos/canary/webrtc-c/build; cd amazon-kinesis-video-streams-demos/canary/webrtc-c/build; cmake .. `
 
 ### Build
-To build the library and the provided samples run make in the build directory you executed CMake.
+To build the library and the provided samples, run make in the build directory you executed CMake.
 
 `make`
 
@@ -116,7 +116,7 @@ TODO
 
 #### Seeding
 
-Seeding is a meta job that its sole job is to bootstrap other jobs, orchestrator and runners. 
+Seeding is a meta job whose sole job is to bootstrap other jobs, orchestrators, and runners. 
 When there's a new change to the seed or the other jobs that were created from the seed, the change will automatically propagate to the other jobs. 
 
 The concept is very similar to [AWS CloudFormation](https://aws.amazon.com/cloudformation/)
@@ -126,7 +126,7 @@ The concept is very similar to [AWS CloudFormation](https://aws.amazon.com/cloud
 
 #### Orchestration
 
-Orchestration is a process of permuting a set of the canary configuration and delegate the works to the runner. The permutation can be ranging from streaming duration, bitrate, device types, regions, etc.
+Orchestration is a process of permuting a set of the canary configuration and delegate the works to the runner. The permutation can range from streaming duration, bitrate, device types, regions, etc.
 
 ![orchestration](./docs/orchestration.png)
 


### PR DESCRIPTION
Fixes typos in all four canary ReadMe files, adds Producer Cpp Canary the home ReadMe.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
