### PR TITLE
Automate profiling dashboard generation

### DIFF
--- a/canary/webrtc-c/README.md
+++ b/canary/webrtc-c/README.md
@@ -109,6 +109,13 @@ the granular access to these metrics.
 | Peer      | ICEHolePunchingDelay           | Milliseconds  | -          | -                   | Measures time taken from start of connectivity checks to when the candidate pair is nominated and peer connection established                                                  |
 | Total     | TimeToFirstFrame               | Milliseconds  | -          | -                   | Measures time taken from offer to sending out first frame                                                                                                                      |
 
+### Profiling dashboard
+To generate the dashboard:
+- Select the `Upload a template file` option in AWS cloudformation console and upload the file from `templates/cfd_profiling_template.yaml` directory 
+- Under parameters, provide the title you would like for the dashboard and profilingId. ProfilingId is the name of the dimension you want to track. In case of this package, the aggregated dimension `WebrtcProfiling` can be used
+- Go through the steps and create the stack. 
+- Check AWS cloudwatch console for the generated dashboard
+
 ## Jenkins
 
 ### Prerequisites

--- a/canary/webrtc-c/templates/cfd_profiling_template.yaml
+++ b/canary/webrtc-c/templates/cfd_profiling_template.yaml
@@ -1,0 +1,390 @@
+Parameters:
+  ProfilingId:
+    Type: String
+  DashboardNameStr:
+    Type: String
+    AllowedPattern: "[a-zA-Z0-9-_]*"
+Resources:
+  ProfilingDashboard:
+    Type: AWS::CloudWatch::Dashboard
+    Properties:
+      DashboardName: !Ref DashboardNameStr
+      DashboardBody: !Sub |
+        {
+          "widgets": [
+            {
+              "type": "metric",
+              "x": 0,
+              "y": 0,
+              "width": 6,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [ "KinesisVideoSDKCanary", "GetTokenTime", "WebRTCSDKCanaryLabel", "${ProfilingId}", { "region": "${AWS::Region}" } ]
+                ],
+                "view": "timeSeries",
+                "region": "${AWS::Region}",
+                "title": "GetTokenTime",
+                "period": 300,
+                "stat": "Average"
+              }
+            },
+            {
+              "type": "metric",
+              "x": 18,
+              "y": 6,
+              "width": 6,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [ "KinesisVideoSDKCanary", "ConnectCallTime", "WebRTCSDKCanaryLabel", "${ProfilingId}", { "region": "${AWS::Region}" } ]
+                ],
+                "view": "timeSeries",
+                "region": "${AWS::Region}",
+                "title": "ConnectCallTime",
+                "period": 300,
+                "stat": "Average"
+              }
+            },
+            {
+              "type": "metric",
+              "x": 18,
+              "y": 18,
+              "width": 6,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [ "KinesisVideoSDKCanary", "OfferToAnswerTime", "WebRTCSDKCanaryLabel", "${ProfilingId}", { "region": "${AWS::Region}" } ]
+                ],
+                "view": "timeSeries",
+                "region": "${AWS::Region}",
+                "title": "OfferToAnswerTime",
+                "period": 300,
+                "stat": "Average"
+              }
+            },
+            {
+              "type": "metric",
+              "x": 0,
+              "y": 6,
+              "width": 6,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [ "KinesisVideoSDKCanary", "GetEndpointCallTime", "WebRTCSDKCanaryLabel", "${ProfilingId}", { "region": "${AWS::Region}" } ]
+                ],
+                "view": "timeSeries",
+                "region": "${AWS::Region}",
+                "title": "GetEndpointCallTime",
+                "period": 300,
+                "stat": "Average"
+              }
+            },
+            {
+              "type": "metric",
+              "x": 12,
+              "y": 0,
+              "width": 6,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [ "KinesisVideoSDKCanary", "DescribeCallTime", "WebRTCSDKCanaryLabel", "${ProfilingId}", { "region": "${AWS::Region}" } ]
+                ],
+                "view": "timeSeries",
+                "region": "${AWS::Region}",
+                "title": "DescribeCallTime",
+                "period": 300,
+                "stat": "Average"
+              }
+            },
+            {
+              "type": "metric",
+              "x": 0,
+              "y": 12,
+              "width": 6,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [ "KinesisVideoSDKCanary", "ConnectClientTotalTime", "WebRTCSDKCanaryLabel", "${ProfilingId}", { "region": "${AWS::Region}" } ]
+                ],
+                "view": "timeSeries",
+                "region": "${AWS::Region}",
+                "title": "ConnectClientTotalTime",
+                "period": 300,
+                "stat": "Average"
+              }
+            },
+            {
+              "type": "metric",
+              "x": 6,
+              "y": 6,
+              "width": 6,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [ "KinesisVideoSDKCanary", "GetIceConfigCallTime", "WebRTCSDKCanaryLabel", "${ProfilingId}", { "region": "${AWS::Region}" } ]
+                ],
+                "view": "timeSeries",
+                "region": "${AWS::Region}",
+                "title": "GetIceConfigCallTime",
+                "period": 300,
+                "stat": "Average"
+              }
+            },
+            {
+              "type": "metric",
+              "x": 12,
+              "y": 6,
+              "width": 6,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [ "KinesisVideoSDKCanary", "FetchClientTotalTime", "WebRTCSDKCanaryLabel", "${ProfilingId}", { "region": "${AWS::Region}" } ]
+                ],
+                "view": "timeSeries",
+                "region": "${AWS::Region}",
+                "title": "FetchClientTotalTime",
+                "period": 300,
+                "stat": "Average"
+              }
+            },
+            {
+              "type": "metric",
+              "x": 0,
+              "y": 18,
+              "width": 6,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [ "KinesisVideoSDKCanary", "CreateCallTime", "WebRTCSDKCanaryLabel", "${ProfilingId}", { "region": "${AWS::Region}" } ]
+                ],
+                "view": "timeSeries",
+                "region": "${AWS::Region}",
+                "title": "CreateCallTime",
+                "period": 300,
+                "stat": "Average"
+              }
+            },
+            {
+              "type": "metric",
+              "x": 6,
+              "y": 0,
+              "width": 6,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [ "KinesisVideoSDKCanary", "CreateClientTotalTime", "WebRTCSDKCanaryLabel", "${ProfilingId}", { "region": "${AWS::Region}" } ]
+                ],
+                "view": "timeSeries",
+                "region": "${AWS::Region}",
+                "title": "CreateClientTotalTime",
+                "period": 300,
+                "stat": "Average"
+              }
+            },
+            {
+              "type": "metric",
+              "x": 12,
+              "y": 12,
+              "width": 6,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [ "KinesisVideoSDKCanary", "LocalCandidateGatheringTime", "WebRTCSDKCanaryLabel", "${ProfilingId}", { "region": "${AWS::Region}" } ]
+                ],
+                "view": "timeSeries",
+                "region": "${AWS::Region}",
+                "title": "LocalCandidateGatheringTime",
+                "period": 300,
+                "stat": "Average"
+              }
+            },
+            {
+              "type": "metric",
+              "x": 6,
+              "y": 24,
+              "width": 6,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [ "KinesisVideoSDKCanary", "IceCandidatePairNominationTime", "WebRTCSDKCanaryLabel", "${ProfilingId}", { "region": "${AWS::Region}" } ]
+                ],
+                "view": "timeSeries",
+                "region": "${AWS::Region}",
+                "title": "IceCandidatePairNominationTime",
+                "period": 300,
+                "stat": "Average"
+              }
+            },
+            {
+              "type": "metric",
+              "x": 12,
+              "y": 18,
+              "width": 6,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [ "KinesisVideoSDKCanary", "IceServerResolutionTime", "WebRTCSDKCanaryLabel", "${ProfilingId}", { "region": "${AWS::Region}" } ]
+                ],
+                "view": "timeSeries",
+                "region": "${AWS::Region}",
+                "title": "IceServerResolutionTime",
+                "period": 300,
+                "stat": "Average"
+              }
+            },
+            {
+              "type": "metric",
+              "x": 18,
+              "y": 18,
+              "width": 6,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [ "KinesisVideoSDKCanary", "IcecandidateGatheringTime", "WebRTCSDKCanaryLabel", "${ProfilingId}", { "region": "${AWS::Region}" } ]
+                ],
+                "view": "timeSeries",
+                "region": "${AWS::Region}",
+                "title": "IcecandidateGatheringTime",
+                "period": 300,
+                "stat": "Average"
+              }
+            },
+            {
+              "type": "metric",
+              "x": 12,
+              "y": 24,
+              "width": 6,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [ "KinesisVideoSDKCanary", "ICEHolePunchingDelay", "WebRTCSDKCanaryLabel", "${ProfilingId}", { "region": "${AWS::Region}" } ]
+                ],
+                "view": "timeSeries",
+                "region": "${AWS::Region}",
+                "title": "ICEHolePunchingDelay",
+                "period": 300,
+                "stat": "Average"
+              }
+            },
+            {
+              "type": "metric",
+              "x": 6,
+              "y": 18,
+              "width": 6,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [ "KinesisVideoSDKCanary", "RelayCandidateSetUpTime", "WebRTCSDKCanaryLabel", "${ProfilingId}", { "region": "${AWS::Region}" } ]
+                ],
+                "view": "timeSeries",
+                "region": "${AWS::Region}",
+                "title": "RelayCandidateSetUpTime",
+                "period": 300,
+                "stat": "Average"
+              }
+            },
+            {
+              "type": "metric",
+              "x": 0,
+              "y": 18,
+              "width": 6,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [ "KinesisVideoSDKCanary", "SrflxCandidateSetUpTime", "WebRTCSDKCanaryLabel", "${ProfilingId}", { "region": "${AWS::Region}" } ]
+                ],
+                "view": "timeSeries",
+                "region": "${AWS::Region}",
+                "title": "SrflxCandidateSetUpTime",
+                "period": 300,
+                "stat": "Average"
+              }
+            },
+            {
+              "type": "metric",
+              "x": 18,
+              "y": 12,
+              "width": 6,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [ "KinesisVideoSDKCanary", "HostCandidateSetUpTime", "WebRTCSDKCanaryLabel", "${ProfilingId}", { "region": "${AWS::Region}" } ]
+                ],
+                "view": "timeSeries",
+                "region": "${AWS::Region}",
+                "title": "HostCandidateSetUpTime",
+                "period": 300,
+                "stat": "Average"
+              }
+            },
+            {
+              "type": "metric",
+              "x": 18,
+              "y": 24,
+              "width": 6,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [ "KinesisVideoSDKCanary", "IceAgentSetUpTime", "WebRTCSDKCanaryLabel", "${ProfilingId}", { "region": "${AWS::Region}" } ]
+                ],
+                "view": "timeSeries",
+                "region": "${AWS::Region}",
+                "title": "IceAgentSetUpTime",
+                "period": 300,
+                "stat": "Average"
+              }
+            },
+            {
+              "type": "metric",
+              "x": 0,
+              "y": 30,
+              "width": 6,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [ "KinesisVideoSDKCanary", "DtlsSetupTime", "WebRTCSDKCanaryLabel", "${ProfilingId}", { "region": "${AWS::Region}" } ]
+                ],
+                "view": "timeSeries",
+                "region": "${AWS::Region}",
+                "title": "DtlsSetupTime",
+                "period": 300,
+                "stat": "Average"
+              }
+            },
+            {
+              "type": "metric",
+              "x": 6,
+              "y": 12,
+              "width": 6,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [ "KinesisVideoSDKCanary", "PcCreationTime", "WebRTCSDKCanaryLabel", "${ProfilingId}", { "region": "${AWS::Region}" } ]
+                ],
+                "view": "timeSeries",
+                "region": "${AWS::Region}",
+                "title": "PcCreationTime",
+                "period": 300,
+                "stat": "Average"
+              }
+            },
+            {
+              "type": "metric",
+              "x": 6,
+              "y": 30,
+              "width": 6,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [ "KinesisVideoSDKCanary", "TimeToFirstFrame", "WebRTCSDKCanaryLabel", "${ProfilingId}", { "region": "${AWS::Region}" } ]
+                ],
+                "view": "timeSeries",
+                "region": "${AWS::Region}",
+                "title": "TimeToFirstFrame",
+                "period": 300,
+                "stat": "Average"
+              }
+            }
+          ]
+        }


### PR DESCRIPTION
Description of changes:

What was changed?

Created a CF template to generate the profiling dashboard on Cloudwatch

Why was it changed?

To simplify the process of creating dashboards

How it was changed?

Added a template that would take in a label and dashboard name as parameter and generate the dashboard when the CF stack is deployed

Testing:

Tested on AWS account and verified the dashboard was indeed generated with the required metrics

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
