### PR TITLE
Upgrade AWS CPP SDK Version for WebRTC-C Canary

### DIFF
--- a/canary/webrtc-c/CMakeLists.txt
+++ b/canary/webrtc-c/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.13)
 project(KVSWebRTCCanary LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 11)
@@ -42,9 +42,13 @@ add_definitions(-DCMAKE_DETECTED_CACERT_PATH)
 include_directories(${cloudwatch_SOURCE_DIR}/aws-cpp-sdk-core/include)
 include_directories(${cloudwatch_SOURCE_DIR}/aws-cpp-sdk-monitoring/include)
 include_directories(${cloudwatch_SOURCE_DIR}/aws-cpp-sdk-logs/include)
+
 include_directories(${webrtc_SOURCE_DIR}/src/include)
 include_directories(${webrtc_SOURCE_DIR}/open-source/include)
 link_directories(${webrtc_SOURCE_DIR}/open-source/lib)
+
+link_directories(${CMAKE_CURRENT_SOURCE_DIR}/build/_deps/lib)
+
 add_library(
   kvsWebrtcCanary
   src/Config.cpp

--- a/canary/webrtc-c/CMakeLists.txt
+++ b/canary/webrtc-c/CMakeLists.txt
@@ -11,6 +11,14 @@ set(ENABLE_TESTING OFF CACHE BOOL "Disable building tests for AWS SDK" FORCE)
 set(BUILD_ONLY "monitoring;logs" CACHE STRING "Tell AWS SDK to only build monitoring and logs" FORCE)
 set(BUILD_SAMPLE OFF CACHE BOOL "Disable sample building for WebRTC library" FORCE)
 
+if (NOT OPEN_SRC_INSTALL_PREFIX)
+  set(OPEN_SRC_INSTALL_PREFIX ${CMAKE_CURRENT_SOURCE_DIR}/build/_deps)
+  set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${OPEN_SRC_INSTALL_PREFIX})
+endif()
+if(NOT EXISTS ${OPEN_SRC_INSTALL_PREFIX})
+  file(MAKE_DIRECTORY ${OPEN_SRC_INSTALL_PREFIX})
+endif()
+
 FetchContent_Declare(
   webrtc
   GIT_REPOSITORY https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c
@@ -20,8 +28,8 @@ FetchContent_Declare(
 FetchContent_Declare(
   cloudwatch
   GIT_REPOSITORY https://github.com/aws/aws-sdk-cpp
-  GIT_TAG        1.9.67
-)
+  GIT_TAG        1.11.143
+  )
 
 FetchContent_GetProperties(webrtc)
 if(NOT webrtc_POPULATED)


### PR DESCRIPTION
## Changes
Updates AWS CPP SDK version from **1.9.67** to **1.11.143** in WebRTC-C Canary.
- `CMAKE_PREFIX_PATH` is now set, and it is set to the dependency build directory `/build/_deps`
  - This solved `undefined reference to 'EVP_idea_cbc@OPENSSL_1_1_0'` errors associated with the following warning by directly specifying which directory to search in for dependencies.
```
Cannot generate a safe runtime search path for target [...] because files in some directories
may conflict with libraries in implicit directories:
    runtime library [libcrypto.so.1.1] in /usr/lib/x86_64-linux-gnu may be hidden by files in:
      /home/ubuntu/amazon-kinesis-video-streams-demos/canary/webrtc-c/build/_deps/webrtc-src/open-source/lib
Some of these libraries may not be found correctly.  
```
- `/build/_deps/lib` is then added to `link_directories` to point to the dependency libraries, preventing the following errors:
```
/usr/bin/ld: cannot find -lkvspicUtils
/usr/bin/ld: cannot find -lkvsCommonLws
/usr/bin/ld: cannot find -lwebsockets
```

## Testing
These changes have been tested by successfully running `cmake`, `make`, and `./kvsWebrtcCanaryWebrtc` and then verifying that metrics are emitting to CloudWatch.

<br>
<br>
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
