### PR TITLE
Sigv4 signer in Swift

### DIFF
--- a/sigv4-signing/swift/.gitignore
+++ b/sigv4-signing/swift/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc
+Pods/

--- a/sigv4-signing/swift/sigv4/Podfile
+++ b/sigv4-signing/swift/sigv4/Podfile
@@ -1,0 +1,12 @@
+target 'Sigv4' do
+  pod 'Starscream', '~> 4.0.6'
+
+  target 'Sigv4CLI' do  
+    inherit! :search_paths
+  end
+
+  target 'Sigv4Tests' do
+    inherit! :search_paths
+  end
+end
+

--- a/sigv4-signing/swift/sigv4/Podfile.lock
+++ b/sigv4-signing/swift/sigv4/Podfile.lock
@@ -1,0 +1,16 @@
+PODS:
+  - Starscream (4.0.6)
+
+DEPENDENCIES:
+  - Starscream (~> 4.0.6)
+
+SPEC REPOS:
+  trunk:
+    - Starscream
+
+SPEC CHECKSUMS:
+  Starscream: fb2c4510bebf908c62bd383bcf05e673720e91fd
+
+PODFILE CHECKSUM: 4f7c8e2da50efcd57c2c881e0696f8dc83496e9a
+
+COCOAPODS: 1.12.1

--- a/sigv4-signing/swift/sigv4/Sigv4CLI/main.swift
+++ b/sigv4-signing/swift/sigv4/Sigv4CLI/main.swift
@@ -1,0 +1,168 @@
+import Foundation
+import Starscream
+import Sigv4
+
+func main() {
+    // Step 1. Obtain AWS Credentials. Some examples of how to obtain these
+    // are AWS Cognito or AWS STS. If using permanent credentials (not
+    // recommended for security reasons), session token can be nil or an empty string.
+    let accessKeyId: String = "YourAccessKey"
+    let secretKeyId: String = "YourSecretKey"
+    let sessionToken: String? = "YourSessionToken"
+    
+    // Step 2. Specify region. For example, "us-west-2".
+    let region: String = "YourRegion"
+    
+    // Step 3. Build the websocket URL to sign. The two operations supported by this signer are:
+    // 1. ConnectAsMaster https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/kvswebrtc-websocket-apis-2.html
+    //    format: wss://{GetSignalingChannelEndpoint API Response (Master Role, WSS)}?X-Amz-ChannelARN={ChannelARN}
+    //    example: wss://m-a1b2c3d4.kinesisvideo.us-west-2.amazonaws.com?X-Amz-ChannelARN=arn:aws:kinesisvideo:us-west-2:123456789012:channel/demo-channel/1234567890123
+    // 2. ConnectAsViewer https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/kvswebrtc-websocket-apis-1.html
+    //    format: {GetSignalingChannelEndpoint API Response (Viewer Role, WSS)}?X-Amz-ChannelARN={ChannelARN}&XX-Amz-ClientId={ClientId}
+    //    example: wss://v-a1b2c3d4.kinesisvideo.us-west-2.amazonaws.com?X-Amz-ChannelARN=arn:aws:kinesisvideo:us-west-2:123456789012:channel/demo-channel/1234567890123&X-Amz-ClientId=d7d1c6e2-9cb0-4d61-bea9-ecb3d3816557
+    //
+    // To obtain the URL host, we need to make the Kinesis Video Streams GetSignalingChannelEndpoint API call.
+    // Using the AWS CLI:
+    //
+    // aws kinesisvideo get-signaling-channel-endpoint --channel-arn {ChannelARN} --single-master-channel-endpoint-configuration='{"Protocols":["WSS"],"Role":"MASTER"}'
+    //
+    // To obtain the ChannelARN given the Signaling Channel Name, you can make the Kinesis Video Streams DescribeSignalingChannel API call.
+    // Using the AWS CLI:
+    //
+    // aws kinesisvideo describe-signaling-channel --channel-name {ChannelName}
+    
+    let urlToSign: URL = URL(string: "wss://...")!
+    
+    // Check if the user is using default values
+    if accessKeyId == "YourAccessKey" || secretKeyId == "YourSecretKey" || sessionToken == "YourSessionToken" || region == "YourRegion" || urlToSign.absoluteString == "wss://..." {
+        print("Please update the default values with your own AWS credentials, region, and construct the websocket URL to sign before running the program.")
+        return
+    }
+    
+    // Step 4. Sign the URL.
+    var request: URLRequest
+    do {
+        request = try Signer.sign(request: URLRequest(url: urlToSign),
+                        credentials: AWSCredentials(accessKey: accessKeyId, secretKey: secretKeyId, sessionToken: sessionToken),
+                        region: region,
+                        currentDate: Date())
+    } catch {
+        print("Error signing request! \(error)")
+        return
+    }
+    
+    // Step 5. Connect to the WebSocket URL using a WebSocket client.
+    // The Kinesis Video Streams WebRTC SDK in iOS offers a WebSocket client implementation that handles
+    // exchanging Signaling messages between WebRTC peers. In this minimal example, we'll use a
+    // SimpleWebSocketClient (implemented below) that connects to the WebSocket, sends a ping, and disconnects.
+    
+    // 5a. Configure the URLRequest
+    request.timeoutInterval = 5
+    request.setValue("aws-kvs-ios-sigv4-signer-sample/1.0.0", forHTTPHeaderField: "User-Agent")
+    
+    // 5b. Initialize WebSocket Client
+    let client: SimpleWebSocketClient = SimpleWebSocketClient(request)
+    
+    // 5c. Connect!
+    print("Connecting to \(request.url!.absoluteString)")
+    client.connect()
+    
+    print("Waiting 5 seconds...")
+    waitNSeconds(5)
+    
+    print("Sending a ping...")
+    client.sendPing()
+    waitNSeconds(3)
+    
+    print("Disconnecting...")
+    client.disconnect()
+    print("Finished!")
+}
+
+/// Waits for a specified duration before stopping the current RunLoop.
+///
+/// - Parameters:
+///   - n: The duration, in seconds, to wait before stopping the RunLoop.
+///
+/// - Important:
+///   This method uses a combination of RunLoop and DispatchQueue to wait for the specified duration
+///   and then stop the RunLoop. It's recommended to avoid busy-waiting loops and use this method
+///   judiciously to prevent unnecessary CPU resource consumption.
+///
+/// - Note:
+///   The RunLoop is stopped by scheduling a task on a DispatchQueue after the specified duration.
+///   This allows the RunLoop to process events until the specified time is reached.
+///
+/// - Parameter n: The duration, in seconds, to wait before stopping the RunLoop.
+private func waitNSeconds(_ n: TimeInterval) {
+    // Calculate the end time
+    let runLoopEndTime = Date().addingTimeInterval(n)
+    
+    // Run the RunLoop until the specified end time
+    RunLoop.current.run(until: runLoopEndTime)
+    
+    // Schedule a task on a DispatchQueue to stop the RunLoop after n seconds
+    DispatchQueue.global().asyncAfter(deadline: .now() + n) {
+        CFRunLoopStop(CFRunLoopGetCurrent())
+    }
+}
+
+
+/// A simple WebSocket client using the Starscream library.
+class SimpleWebSocketClient: WebSocketDelegate {
+    /// The underlying WebSocket instance.
+    private var socket: WebSocket?
+    
+    /// Initializes a new WebSocket client with the specified URLRequest.
+    ///
+    /// - Parameter request: The URLRequest for the WebSocket connection.
+    init(_ request: URLRequest) {
+        socket = WebSocket(request: request)
+        socket?.delegate = self
+    }
+    
+    /// Connects to the WebSocket server.
+    func connect() {
+        socket!.connect()
+    }
+    
+    /// Send a Ping message.
+    func sendPing() {
+        socket!.write(ping: Data())
+    }
+    
+    /// Disconnects from the WebSocket server.
+    func disconnect() {
+        socket!.disconnect()
+    }
+    
+    // MARK: - WebSocketDelegate
+    
+    /// Called when the WebSocket client receives an event.
+    ///
+    /// - Parameters:
+    ///   - event: The WebSocket event.
+    ///   - client: The WebSocket client.
+    func didReceive(event: Starscream.WebSocketEvent, client: Starscream.WebSocketClient) {
+        switch event {
+        case .connected:
+            print("WebSocket connected successfully!")
+        case .disconnected(let reason, _):
+            print("WebSocket disconnected: \(reason)")
+        case .text(let string):
+            print("Received text: \(string)")
+        case .binary(let data):
+            print("Received binary data: \(data)")
+        case .pong:
+            print("Received Pong")
+        case .ping:
+            print("Received Ping")
+        case .error(let error):
+            print("WebSocket error: \(error?.localizedDescription ?? "Unknown error")")
+        default:
+            break
+        }
+    }
+}
+
+main()

--- a/sigv4-signing/swift/sigv4/Sigv4Signer/Signer.swift
+++ b/sigv4-signing/swift/sigv4/Sigv4Signer/Signer.swift
@@ -1,0 +1,461 @@
+import Foundation
+import CommonCrypto
+
+public struct AWSCredentials {
+    let accessKey: String
+    let secretKey: String
+    let sessionToken: String?
+    
+    public init(accessKey: String, secretKey: String, sessionToken: String?) {
+        self.accessKey = accessKey
+        self.secretKey = secretKey
+        self.sessionToken = sessionToken
+    }
+}
+
+enum SignerError: Error {
+    case illegalArgument(String)
+    case badUrl(String)
+}
+
+/// SigV4 Signer sample reference for the Kinesis Video Streams WebRTC WebSocket connections
+public class Signer {
+    
+    /// Constructs and signs the Kinesis Video Streams Signaling WebRTC WebSocket Connect URI with Query
+    /// Parameters to connect to Kinesis Video Signaling. This method is responsible for signing the URLRequest
+    /// using the AWS Signature Version 4 process. It adds the necessary AWS-specific headers, including X-Amz-Date,
+    /// X-Amz-Expires, and X-Amz-Signature, to the request.
+    ///
+    /// - Parameters:
+    ///   - request: The Secure Websocket URLRequest to sign.
+    ///     - Important: The URL to sign should be a pre-constructed AWS Kinesis Video Streams WebSocket Connect
+    ///       URI, including the necessary query parameters. The URI structure depends on the specific operation. Use
+    ///       the GetSignalingChannelEndpoint API to obtain the host name. The two supported operations are:
+    ///       - Connect as Master (GetSignalingChannelEndpoint - master role):
+    ///         Example: wss://m-a1b2c3d4.kinesisvideo.us-west-2.amazonaws.com?X-Amz-ChannelARN=arn:aws:kinesisvideo:us-west-2:123456789012:channel/demo-channel/1234567890123
+    ///         Ref: https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/kvswebrtc-websocket-apis-2.html
+    ///       - Connect as Viewer (GetSignalingChannelEndpoint - viewer role):
+    ///         Example: wss://v-a1b2c3d4.kinesisvideo.us-west-2.amazonaws.com?X-Amz-ChannelARN=arn:aws:kinesisvideo:us-west-2:123456789012:channel/demo-channel/1234567890123&X-Amz-ClientId=d7d1c6e2-9cb0-4d61-bea9-ecb3d3816557
+    ///         Ref: https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/kvswebrtc-websocket-apis-1.html
+    ///     - Note: The base signaling channel endpoints are different depending on the role (master/viewer) specified in the
+    ///       GetSignalingChannelEndpoint API call.
+    ///       Ref: https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/API_SingleMasterChannelEndpointConfiguration.html#KinesisVideo-Type-SingleMasterChannelEndpointConfiguration-Role
+    ///   - credentials: The AWS credentials for authentication, including access key, secret key, and optional session token.
+    ///   - region: The AWS region where the service resides (e.g., "us-west-2").
+    ///   - currentDate: The current date used for signing. The signed URL is valid for 5 minutes from this date.
+    ///
+    /// - Returns: A signed URLRequest ready to connect to Kinesis Video Streams Signaling.
+    ///
+    /// - Throws: An error of type `SignerError` if any issues occur during the signing process.
+    ///
+    /// - Example:
+    ///   ```swift
+    ///   let unsignedRequest = URLRequest(url: URL(string: "https://example.com/path/to/resource")!)
+    ///   let credentials = AWSCredentials(accessKey: "YourAccessKey", secretKey: "YourSecretKey", sessionToken: "YourSessionToken")
+    ///   let region = "YourChannelRegion"
+    ///   let currentDate = Date()
+    ///   do {
+    ///       let signedRequest = try Signer.sign(request: unsignedRequest, credentials: credentials, region: region, currentDate: currentDate)
+    ///       // Use a websocket client to connect to this secure websocket URL...
+    ///   } catch {
+    ///       print("Error signing the request: \(error)")
+    ///   }
+    ///   ```
+    ///
+    /// - SeeAlso: [Signing AWS requests with Signature Version 4](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html)
+    public static func sign(request: URLRequest, credentials: AWSCredentials, region: String, currentDate: Date) throws -> URLRequest {
+        guard let url = request.url, let host = url.host() else {
+            throw SignerError.badUrl("A URL with a host is required!")
+        }
+        
+        let amzDate: String = getTimeStamp(currentDate)
+        let dateStamp: String = getDateStamp(currentDate)
+        
+        var queryParametersMap: [(String, String)]
+        do {
+            queryParametersMap = try buildQueryParamsMap(url: url, accessKey: credentials.accessKey, sessionToken: credentials.sessionToken, region: region, amzDate: amzDate, dateStamp: dateStamp)
+        } catch SignerError.illegalArgument(let message) {
+            throw SignerError.badUrl(message)
+        }
+        
+        let canonicalQuerystring: String = getCanonicalizedQueryString(&queryParametersMap)
+        let canonicalRequest: String = buildCanonicalRequest(url: url, canonicalQueryString: canonicalQuerystring)
+        let stringToSign: String = signString(canonicalRequest: canonicalRequest, amzDate: amzDate, credentialScope: buildCredentialScope(region: region, dateStamp: dateStamp))
+        let signingKey: Data = getSignatureKey(key: credentials.secretKey, dateStamp: dateStamp, regionName: region, service: SignerConstants.SERVICE)
+        
+        let signature: String = hmacSHA256(stringToSign, key: signingKey).hexString
+        
+        return URLRequest(url: URL(string: "wss://\(host)\(url.path())/?\(canonicalQuerystring)&\(SignerConstants.X_AMZ_SIGNATURE)=\(signature)")!)
+    }
+    
+    /// Builds a list of query parameters for AWS request signing based on the provided URL and additional parameters.
+    ///
+    /// This method constructs a list of query parameters necessary for AWS request signing. It includes standard parameters
+    /// such as X-Amz-Algorithm, X-Amz-Credential, X-Amz-Date, X-Amz-Expires, and X-Amz-SignedHeaders. Additionally, it
+    /// includes any query parameters present in the original request URL.
+    ///
+    /// - Example:
+    ///   ```swift
+    ///   let url = URL(string: "https://example.com?param2=value2&param1=value1")!
+    ///   let accessKey = "AKIAIOSFODNN7EXAMPLE"
+    ///   let sessionToken = "AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+FvwqnKwRcOIfrRh3c/LTo6UDdyJwOOvEVPvLXCrrrUtdnniCEXAMPLE/IvU1dYUg2RVAJBanLiHb4IgRmpRV3zrkuWJOgQs8IZZaIv2BXIa2R4OlgkBN9bkUDNCJiBeb/AXlzBBko7b15fjrBs2+cTQtpZ3CYWFXG8C5zqx37wnOE49mRl/+OtkIKGO7fAE"
+    ///   let region = "us-west-2"
+    ///   let amzDate = "20230718T191301Z"
+    ///   let dateStamp = "20230718"
+    ///   let queryParams = try buildQueryParamsMap(url: url, accessKey: accessKey, sessionToken: sessionToken, region: region, amzDate: amzDate, dateStamp: dateStamp)
+    ///   print(queryParams)
+    ///   ```
+    ///   Output: `[("X-Amz-Algorithm", "AWS4-HMAC-SHA256"), ("X-Amz-Credential", "AKIAIOSFODNN7EXAMPLE%2F20230718%2Fus-west-2%2Fkinesisvideo%2Faws4_request"), ("X-Amz-Date", "20230718T191301Z"), ("X-Amz-Expires", "299"), ("X-Amz-SignedHeaders", "host"), ("param1", "value1"), ("param2", "value2")]`
+    ///
+    /// - Parameters:
+    ///   - url: The URL to sign.
+    ///   - accessKey: The AWS access key used for signing.
+    ///   - sessionToken: The optional AWS session token. If provided, X-Amz-Security-Token is added to the parameters and the session token is encoded and assigned as its value.
+    ///   - region: The AWS region.
+    ///   - amzDate: The formatted date for X-Amz-Date: "yyyyMMdd'T'HHmmss'Z'".
+    ///   - dateStamp: The date stamp used in the credential scope: "yyyyMMdd".
+    ///
+    /// - Returns: An array of key-value pairs representing the query parameters for AWS request signing.
+    ///
+    /// - Throws: An error of type `SignerError` if the query parameters included in the original url are malformed.
+    ///
+    /// - Note:
+    ///   The query parameters are not guaranteed to be ordered alphabetically based on their keys.
+    ///
+    /// - SeeAlso: [Query string components](https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html#query-string-components)
+    ///
+    /// - SeeAlso: [Canonical request specification](https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html#create-canonical-request)
+    static func buildQueryParamsMap(url: URL,
+                                    accessKey: String,
+                                    sessionToken: String?,
+                                    region: String,
+                                    amzDate: String,
+                                    dateStamp: String) throws -> [(String, String)] {
+        
+        var keyValuePairs: [(String, String)] = []
+        keyValuePairs.append((SignerConstants.X_AMZ_ALGORITHM, SignerConstants.ALGORITHM_AWS4_HMAC_SHA_256))
+        keyValuePairs.append((SignerConstants.X_AMZ_CREDENTIAL, urlEncode("\(accessKey)/\(buildCredentialScope(region: region, dateStamp: dateStamp))")))
+        keyValuePairs.append((SignerConstants.X_AMZ_DATE, amzDate))
+        keyValuePairs.append((SignerConstants.X_AMZ_EXPIRES, "299"))
+        keyValuePairs.append((SignerConstants.X_AMZ_SIGNED_HEADERS, SignerConstants.SIGNED_HEADERS))
+        
+        if let unwrappedSessionToken: String = sessionToken, !unwrappedSessionToken.isEmpty {
+            keyValuePairs.append((SignerConstants.X_AMZ_SECURITY_TOKEN, urlEncode(unwrappedSessionToken)))
+        }
+        
+        // Add the query parameters included in the original request as well
+        // Note: query parameters follow the format: key1=val1&key2=val2&key3=val3
+        let queryParams: [String] = (url.query ?? "").components(separatedBy: "&")
+        
+        // If there are no query parameters, exit.
+        if queryParams == [""] {
+            return keyValuePairs
+        }
+        
+        // Check that there are no two "&"'s in a row.
+        if queryParams.count > 1 && queryParams.contains("") {
+            throw SignerError.illegalArgument("Malformed query string!")
+        }
+        
+        // Parse key-value pairs
+        for param in queryParams {
+            let pair = param.components(separatedBy: "=")
+            guard pair.count == 2 else {
+                throw SignerError.illegalArgument("Illegal query parameter: \(param)")
+            }
+            keyValuePairs.append((pair[0], urlEncode(pair[1])))
+        }
+        
+        return keyValuePairs
+    }
+    
+    /// Gets the canonicalized query string for AWS request signing.
+    ///
+    /// This method takes an array of query parameters in the form of key-value pairs and sorts them lexicographically
+    /// based on the parameter names. It then reconstructs the sorted query string in the form "key1=value1&key2=value2".
+    ///
+    /// - Example:
+    ///   ```swift
+    ///   var queryParams = [("X-Amz-Expires", "299"), ("X-Amz-Algorithm", "AWS4-HMAC-SHA256"), ("X-Amz-Date", "20230718T191301Z")]
+    ///   let canonicalQueryString = getCanonicalizedQueryString(&queryParams)
+    ///   print(canonicalQueryString)
+    ///   ```
+    ///   Output: `"X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20230718T191301Z&X-Amz-Expires=299"`
+    ///
+    /// - Parameter queryParamsMap: An inout array of query parameters represented as key-value pairs.
+    ///   The array is sorted lexicographically based on the parameter names. It should contain the following parameters:
+    ///   X-Amz-Algorithm, X-Amz-ChannelARN, X-Amz-ClientId (if viewer), X-Amz-Credential, X-Amz-Date, X-Amz-Expires.
+    ///
+    /// - Returns: The canonicalized query string.
+    ///
+    /// - Important:
+    ///   This method is an essential step in the AWS request signing process, ensuring that the query parameters are
+    ///   sorted before creating the canonical request.
+    ///
+    /// - Note:
+    ///   The `queryParamsMap` parameter is an inout parameter, meaning it is modified directly in the function.
+    ///
+    /// - SeeAlso: [Query string components](https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html#query-string-components)
+    ///
+    /// - SeeAlso: [Canonical request specification](https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html#create-canonical-request)
+    static func getCanonicalizedQueryString(_ queryParamsMap: inout [(String, String)]) -> String {
+        // Sort the key-value pairs based on the keys
+        queryParamsMap.sort { $0.0 < $1.0 }
+        
+        // Reconstruct the sorted query string
+        return queryParamsMap.map { "\($0.0)=\($0.1)" }.joined(separator: "&")
+    }
+    
+    /// Builds and returns the canonical request for an AWS request.
+    ///
+    /// An example canonical request looks like the following:
+    /// ```
+    /// GET
+    /// /
+    /// X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-ChannelARN=arn%3Aaws%3Akinesisvideo%3Aus-west-2%3A123456789012%3Achannel%2Fdemo-channel%2F1234567890123&X-Amz-ClientId=d7d1c6e2-9cb0-4d61-bea9-ecb3d3816557&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230718%2Fus-west-2%2Fkinesisvideo%2Faws4_request&X-Amz-Date=20230718T191301Z&X-Amz-Expires=299&X-Amz-SignedHeaders=host
+    /// host:v-1a2b3c4d.kinesisvideo.us-west-2.amazonaws.com
+    ///
+    /// host
+    /// e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    /// ```
+    ///
+    /// The format of the canonical request is as follows:
+    /// 1. `{HTTP method}\n` - With presigned URLs, it's always `GET`.
+    /// 2. `{Canonical URI}\n` - Resource path. In this case, it's always `/`. 
+    /// 3. `{Canonical Query String}\n` - Sorted list of query parameters (and their values), excluding X-Amz-Signature, already URL-encoded.
+    ///    In this case: X-Amz-Algorithm, X-Amz-ChannelARN, X-Amz-ClientId (if viewer), X-Amz-Credential, X-Amz-Date, X-Amz-Expires.
+    /// 4. `{Canonical Headers}\n` - In this case, we only have the required HTTP `host` header.
+    /// 5. `{Signed Headers}\n` - Which headers, from the canonical headers, in alphabetical order.
+    /// 6. `{Hashed Payload}` - In this case, it's always the SHA-256 checksum of an empty string.
+    ///
+    /// - Parameters:
+    ///   - url: The URL of the request. The canonical URI is determined based on the path of the provided URL. If the path
+    ///   is empty, a forward slash ("/") is used.
+    ///   - canonicalQueryString: The canonical query string for the request. Should contain the following parameters: X-Amz-Algorithm, X-Amz-ChannelARN, X-Amz-ClientId (if viewer), X-Amz-Credential, X-Amz-Date, X-Amz-Expires.
+    ///
+    /// - Returns: The canonical request string.
+    ///
+    /// - SeeAlso: [Creating a Canonical Request](https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html)
+    ///
+    /// - Parameters:
+    ///   - url: The URL to sign. For example, `wss://v-a1b2c3d4.kinesisvideo.us-west-2.amazonaws.com?
+    ///     X-Amz-ChannelARN=arn:aws:kinesisvideo:us-west-2:123456789012:channel/demo-channel/1234567890123&X-Amz-ClientId=d7d1c6e2-9cb0-4d61-bea9-ecb3d3816557`.
+    ///   - canonicalQuerystring: The Canonical Query String to use in the Canonical Request. Sorted list of query
+    ///     parameters (and their values) already URL-encoded. Should include X-Amz-Algorithm, X-Amz-ChannelARN, X-Amz-ClientId (if viewer), X-Amz-Credential, X-Amz-Date, X-Amz-Expires and not include X-Amz-Signature.
+    ///
+    /// - SeeAlso: [URL encoding](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html#w28981aab9c27c27c11.UriEncode%28%29:~:text=or%20trailing%20whitespace.-,UriEncode(),-URI%20encode%20every)
+    /// - SeeAlso: [Canonical request specification](https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html#create-canonical-request)
+    static func buildCanonicalRequest(url: URL, canonicalQueryString: String) -> String {
+        let canonicalURI: String = url.path.isEmpty ? "/" : url.path
+        let canonicalHeaders: String = buildCanonicalHeaders(url)
+        let payloadHash: String = sha256("".data(using: .utf8)!).hexString
+        
+        return """
+            \(SignerConstants.METHOD)
+            \(canonicalURI)
+            \(canonicalQueryString)
+            \(canonicalHeaders)
+            
+            \(SignerConstants.SIGNED_HEADERS)
+            \(payloadHash)
+            """
+    }
+    
+    /// Builds and returns the canonical headers for the AWS request.
+    ///
+    /// The canonical headers are constructed by including the "host" header with the
+    /// host information extracted from the provided URL.
+    ///
+    /// - Parameter url: The URL of the request.
+    ///
+    /// - Returns: The canonical headers string
+    ///
+    /// - SeeAlso: [Canonical Headers](https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-headers.html)
+    static func buildCanonicalHeaders(_ url: URL) -> String {
+        return "host:\(url.host()!)"
+    }
+    
+    /// Creates and returns the string to sign for AWS request signing.
+    ///
+    /// The string to sign is constructed by combining the hashing algorithm used, the
+    /// formatted timestamp (amzDate), the credential scope, and the hashed canonical request. The string to sign is formatted as follows:
+    /// ```
+    /// AWS4-HMAC-SHA256
+    /// {amzDate}
+    /// {credentialScope}
+    /// {hashedCanonicalRequest}
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - canonicalRequest: The canonical request string. This function will hash this using the HMAC-SHA256 algorithm.
+    ///   - amzDate: The formatted timestamp in the format "yyyyMMdd'T'HHmmss'Z'".
+    ///   - credentialScope: The credential scope used in the request signing process.
+    ///
+    /// - Returns: The string to sign for AWS request signing.
+    ///
+    /// - SeeAlso: [String to Sign](https://docs.aws.amazon.com/general/latest/gr/sigv4-create-string-to-sign.html)
+    static func signString(canonicalRequest: String, amzDate: String, credentialScope: String) -> String {
+        return """
+            \(SignerConstants.ALGORITHM_AWS4_HMAC_SHA_256)
+            \(amzDate)
+            \(credentialScope)
+            \(sha256(canonicalRequest.data(using: .utf8)!).hexString)
+            """
+    }
+
+    
+    /// Builds the credential scope required for AWS request signing.
+    ///
+    /// The credential scope is constructed by combining the date stamp, AWS region, service name,
+    /// and AWS request type in the following format:
+    /// ```
+    /// {dateStamp}/{region}/{service}/{AWS4_REQUEST_TYPE}
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - region: The AWS region where the request is made, e.g., "us-west-2".
+    ///   - dateStamp: The date stamp in the format "yyyyMMdd".
+    ///
+    /// - Returns: The credential scope string.
+    ///
+    /// - SeeAlso: [AWS Request Signing](https://docs.aws.amazon.com/general/latest/gr/sigv4-create-string-to-sign.html)
+    static func buildCredentialScope(region: String, dateStamp: String) -> String {
+        return "\(dateStamp)/\(region)/\(SignerConstants.SERVICE)/\(SignerConstants.AWS4_REQUEST_TYPE)"
+    }
+
+    
+    /// Calculates and returns the signature key used in the AWS signing process.
+    ///
+    /// The formula for generating the signature key is as follows:
+    /// ```
+    /// kDate = hash("AWS4" + Key, Date)
+    /// kRegion = hash(kDate, Region)
+    /// kService = hash(kRegion, ServiceName)
+    /// kSigning = hash(kService, "aws4_request")
+    /// kSignature = hash(kSigning, string-to-sign)
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - key: AWS secret access key.
+    ///   - dateStamp: Date used in the credential scope. Format: yyyyMMdd.
+    ///   - regionName: AWS region. Example: us-west-2.
+    ///   - serviceName: The name of the service. Should be `kinesisvideo`.
+    /// - Returns: `kSignature` as specified above.
+    ///
+    /// - SeeAlso: [Calculate Signature Documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html#calculate-signature)
+    static func getSignatureKey(key: String, dateStamp: String, regionName: String, service: String) -> Data {
+        let kDate = hmacSHA256(dateStamp, key: ("AWS4" + key).data(using: .utf8)!)
+        let kRegion = hmacSHA256(regionName, key: kDate)
+        let kService = hmacSHA256(service, key: kRegion)
+        let kSigning = hmacSHA256(SignerConstants.AWS4_REQUEST_TYPE, key: kService)
+        return kSigning
+    }
+    
+    /// Calculates the HMAC-SHA256 hash value for the given data and key.
+    ///
+    /// - Parameters:
+    ///   - data: The string data to be hashed.
+    ///   - key: The key used in the HMAC-SHA256 calculation.
+    /// - Returns: The resulting HMAC-SHA256 hash value as raw data.
+    static func hmacSHA256(_ data: String, key: Data) -> Data {
+        // Convert the string data to UTF-8 encoded data
+        let dataToSign = data.data(using: .utf8) ?? Data()
+        
+        // Prepare an array to store the resulting hash value
+        var result = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+        
+        // Perform the HMAC-SHA256 calculation
+        dataToSign.withUnsafeBytes { dataToSignBuffer in
+            key.withUnsafeBytes { keyDataBuffer in
+                CCHmac(CCHmacAlgorithm(kCCHmacAlgSHA256),
+                       keyDataBuffer.baseAddress,
+                       keyDataBuffer.count,
+                       dataToSignBuffer.baseAddress,
+                       dataToSignBuffer.count,
+                       &result)
+            }
+        }
+        
+        // Return the hash value as raw data
+        return Data(result)
+    }
+    
+    /// Calculates the SHA-256 hash of the given data.
+    ///
+    /// - Parameters:
+    ///   - data: The input data for which the SHA-256 hash needs to be calculated.
+    /// - Returns: The SHA-256 hash of the input data.
+    static private func sha256(_ data: Data) -> Data {
+        // Prepare an array to store the resulting hash value
+        var result = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+        
+        // Perform the SHA-256 calculation
+        data.withUnsafeBytes { bytes in
+            _ = CC_SHA256(bytes.baseAddress, CC_LONG(data.count), &result)
+        }
+
+        // Return the hash value as raw data
+        return Data(result)
+    }
+
+    
+    /// URL-encodes the given string, making it safe for inclusion in a URL.
+    /// This function uses the .urlHostAllowed character set for URL encoding.
+    /// Additionally, it replaces the characters '+' with '%2B' and '=' with '%3D',
+    /// which are commonly used in query parameters.
+    ///
+    /// - Parameters:
+    ///   - toEncode: The string to be URL-encoded.
+    /// - Returns: A URL-encoded string, or an empty string if the input is nil.
+    static func urlEncode(_ toEncode: String) -> String {
+        return toEncode.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)!
+            .replacingOccurrences(of: "+", with: "%2B")
+            .replacingOccurrences(of: "=", with: "%3D")
+    }
+
+    /// Returns a formatted timestamp string based on the provided date.
+    ///
+    /// This function formats the given date in the "yyyyMMdd'T'HHmmss'Z'" format
+    /// and returns the resulting timestamp string.
+    ///
+    /// - Parameter date: The date to be formatted.
+    /// - Returns: A formatted timestamp string.
+    static func getTimeStamp(_ date: Date) -> String {
+        return formatDate(date, format: "yyyyMMdd'T'HHmmss'Z'")
+    }
+
+    /// Returns a formatted date stamp string based on the provided date.
+    ///
+    /// This function formats the given date in the "yyyyMMdd" format
+    /// and returns the resulting date stamp string.
+    ///
+    /// - Parameter date: The date to be formatted.
+    /// - Returns: A formatted date stamp string.
+    static func getDateStamp(_ date: Date) -> String {
+        return formatDate(date, format: "yyyyMMdd")
+    }
+
+    
+    /// Formats the provided date using the specified format and returns the result as a string.
+    ///
+    /// This function uses the DateFormatter to format the given date based on the provided format string.
+    /// The time zone is set to UTC by default.
+    ///
+    /// - Parameters:
+    ///   - date: The date to be formatted.
+    ///   - format: The format string used for date formatting.
+    /// - Returns: A string representation of the formatted date.
+    private static func formatDate(_ date: Date, format: String) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = format
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        return formatter.string(from: date)
+    }
+
+}
+
+extension Data {
+    var hexString: String {
+        return map { String(format: "%02hhx", $0) }.joined()
+    }
+}

--- a/sigv4-signing/swift/sigv4/Sigv4Signer/SignerConstants.swift
+++ b/sigv4-signing/swift/sigv4/Sigv4Signer/SignerConstants.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public final class SignerConstants {
+    static let ALGORITHM_AWS4_HMAC_SHA_256 = "AWS4-HMAC-SHA256"
+    static let AWS4_REQUEST_TYPE = "aws4_request"
+    static let SERVICE = "kinesisvideo"
+    static let X_AMZ_ALGORITHM = "X-Amz-Algorithm"
+    static let X_AMZ_CREDENTIAL = "X-Amz-Credential"
+    static let X_AMZ_DATE = "X-Amz-Date"
+    static let X_AMZ_EXPIRES = "X-Amz-Expires"
+    static let X_AMZ_SECURITY_TOKEN = "X-Amz-Security-Token"
+    static let X_AMZ_SIGNATURE = "X-Amz-Signature"
+    static let X_AMZ_SIGNED_HEADERS = "X-Amz-SignedHeaders"
+    static let NEW_LINE_DELIMITER = "\n"
+    static let DATE_PATTERN = "yyyyMMdd"
+    static let TIME_PATTERN = "yyyyMMdd'T'HHmmss'Z'"
+    static let METHOD = "GET"
+    static let SIGNED_HEADERS = "host"
+}

--- a/sigv4-signing/swift/sigv4/Sigv4Signer/main.swift
+++ b/sigv4-signing/swift/sigv4/Sigv4Signer/main.swift
@@ -1,0 +1,59 @@
+//import Foundation
+//import Starscream
+//
+//class WebSocketExample: WebSocketDelegate {
+//    private var socket: WebSocket?
+//
+//    func main() {
+//        // Initialize WebSocket with the desired URL
+//        let socketURL = URL(string: "wss://socketsbay.com/wss/v2/1/demo/")!
+//        var request = URLRequest(url: socketURL)
+//        request.timeoutInterval = 5
+//
+//        // Create a WebSocket instance
+//        socket = WebSocket(request: request)
+//        socket?.delegate = self
+//
+//        // Connect to the WebSocket server
+//        socket?.connect()
+//    }
+//
+//    // MARK: - WebSocketDelegate
+//
+//    func didReceive(event: Starscream.WebSocketEvent, client: Starscream.WebSocketClient) {
+//        switch event {
+//        case .connected:
+//            print("WebSocket connected successfully!")
+//        case .disconnected(let reason, _):
+//            print("WebSocket disconnected: \(reason)")
+//        case .text(let string):
+//            print("Received text: \(string)")
+//        case .binary(let data):
+//            print("Received binary data: \(data)")
+//        case .pong:
+//            print("Received Pong")
+//        case .ping:
+//            print("Received Ping")
+//        case .error(let error):
+//            print("WebSocket error: \(error?.localizedDescription ?? "Unknown error")")
+//        default:
+//            break
+//        }
+//    }
+//}
+//
+//// Entry point of the program
+//let example = WebSocketExample()
+//example.main()
+//
+// Run the runloop to keep the program alive
+//RunLoop.current.run()
+
+// Example usage:
+let credentials = AWSCredentials(accessKey: "your_access_key", secretKey: "your_secret_key", sessionToken: nil)
+//let url = URL(string: "your_request_url")!
+//var request = URLRequest(url: url)
+//request.httpMethod = "GET"
+//
+//let signedRequest = KVSSigner.sign(request, credentials: credentials, serviceName: "your_service_name", region: "your_region")
+//print(signedRequest)

--- a/sigv4-signing/swift/sigv4/Sigv4Signer/sigv4Framework.docc/sigv4Framework.md
+++ b/sigv4-signing/swift/sigv4/Sigv4Signer/sigv4Framework.docc/sigv4Framework.md
@@ -1,0 +1,13 @@
+# ``sigv4Framework``
+
+<!--@START_MENU_TOKEN@-->Summary<!--@END_MENU_TOKEN@-->
+
+## Overview
+
+<!--@START_MENU_TOKEN@-->Text<!--@END_MENU_TOKEN@-->
+
+## Topics
+
+### <!--@START_MENU_TOKEN@-->Group<!--@END_MENU_TOKEN@-->
+
+- <!--@START_MENU_TOKEN@-->``Symbol``<!--@END_MENU_TOKEN@-->

--- a/sigv4-signing/swift/sigv4/Sigv4Signer/sigv4Framework.h
+++ b/sigv4-signing/swift/sigv4/Sigv4Signer/sigv4Framework.h
@@ -1,0 +1,18 @@
+//
+//  sigv4Framework.h
+//  sigv4Framework
+//
+//  Created by Gunawan, Jeremy on 11/29/23.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for sigv4Framework.
+FOUNDATION_EXPORT double sigv4FrameworkVersionNumber;
+
+//! Project version string for sigv4Framework.
+FOUNDATION_EXPORT const unsigned char sigv4FrameworkVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <sigv4Framework/PublicHeader.h>
+
+

--- a/sigv4-signing/swift/sigv4/Sigv4Tests/Sigv4Tests.swift
+++ b/sigv4-signing/swift/sigv4/Sigv4Tests/Sigv4Tests.swift
@@ -1,0 +1,309 @@
+import XCTest
+@testable import Sigv4
+
+final class Sigv4Tests: XCTestCase {
+    
+    func test_when_signMasterURLWithTemporaryCredentials_then_returnValidSignedURL() throws {
+        let masterURIToSignProtocolAndHost = "wss://m-a1b2c3d4.kinesisvideo.us-west-2.amazonaws.com"
+        let uriToSign = URL(string: masterURIToSignProtocolAndHost + "?X-Amz-ChannelARN=arn:aws:kinesisvideo:us-west-2:123456789012:channel/demo-channel/1234567890123")!
+        let accessKeyId = "AKIAIOSFODNN7EXAMPLE"
+        let secretKeyId = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        let sessionToken = "AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+FvwqnKwRcOIfrRh3c/LTo6UDdyJwOOvEVPvLXCrrrUtdnniCEXAMPLE/IvU1dYUg2RVAJBanLiHb4IgRmpRV3zrkuWJOgQs8IZZaIv2BXIa2R4OlgkBN9bkUDNCJiBeb/AXlzBBko7b15fjrBs2+cTQtpZ3CYWFXG8C5zqx37wnOE49mRl/+OtkIKGO7fAE"
+        let region = "us-west-2"
+        let dateSecs: TimeInterval = 1690186022.951
+        
+        let expected = URLRequest(url: URL(string: "\(masterURIToSignProtocolAndHost)/?\(SignerConstants.X_AMZ_ALGORITHM)=\(SignerConstants.ALGORITHM_AWS4_HMAC_SHA_256)&X-Amz-ChannelARN=arn%3Aaws%3Akinesisvideo%3Aus-west-2%3A123456789012%3Achannel%2Fdemo-channel%2F1234567890123&\(SignerConstants.X_AMZ_CREDENTIAL)=\(accessKeyId)%2F20230724%2F\(region)%2F\(SignerConstants.SERVICE)%2F\(SignerConstants.AWS4_REQUEST_TYPE)&\(SignerConstants.X_AMZ_DATE)=20230724T080702Z&\(SignerConstants.X_AMZ_EXPIRES)=299&\(SignerConstants.X_AMZ_SECURITY_TOKEN)=AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT%2BFvwqnKwRcOIfrRh3c%2FLTo6UDdyJwOOvEVPvLXCrrrUtdnniCEXAMPLE%2FIvU1dYUg2RVAJBanLiHb4IgRmpRV3zrkuWJOgQs8IZZaIv2BXIa2R4OlgkBN9bkUDNCJiBeb%2FAXlzBBko7b15fjrBs2%2BcTQtpZ3CYWFXG8C5zqx37wnOE49mRl%2F%2BOtkIKGO7fAE&\(SignerConstants.X_AMZ_SIGNED_HEADERS)=\(SignerConstants.SIGNED_HEADERS)&\(SignerConstants.X_AMZ_SIGNATURE)=f8fed632bbe38ac920c7ed2eeaba1a4ba5e2b1bd7aada9f852708112eab76baa")!)
+        
+        let actual = try Signer.sign(request: URLRequest(url: uriToSign), credentials: AWSCredentials(accessKey: accessKeyId, secretKey: secretKeyId, sessionToken: sessionToken), region: region, currentDate: Date(timeIntervalSince1970: dateSecs))
+        
+        XCTAssertEqual(expected, actual)
+    }
+    
+    func test_when_signMasterURLWithLongTermCredentials_then_returnValidSignedURL() throws {
+        let masterURIToSignProtocolAndHost: String = "wss://m-a1b2c3d4.kinesisvideo.us-west-2.amazonaws.com"
+        let uriToSignString: String = "\(masterURIToSignProtocolAndHost)?X-Amz-ChannelARN=arn:aws:kinesisvideo:us-west-2:123456789012:channel/demo-channel/1234567890123"
+        let uriToSign: URL = URL(string: uriToSignString)!
+
+        let accessKeyId: String = "AKIAIOSFODJJ7EXAMPLE"
+        let secretKeyId: String = "wJalrXUtnFEMI/K7MDENG/bPxQQiCYEXAMPLEKEY"
+        let sessionToken: String? = nil
+        let region: String = "us-west-2"
+        let dateSecs: TimeInterval = 1690186022.101
+
+        let expectedString: String = "\(masterURIToSignProtocolAndHost)/?\(SignerConstants.X_AMZ_ALGORITHM)=\(SignerConstants.ALGORITHM_AWS4_HMAC_SHA_256)&X-Amz-ChannelARN=arn%3Aaws%3Akinesisvideo%3Aus-west-2%3A123456789012%3Achannel%2Fdemo-channel%2F1234567890123&\(SignerConstants.X_AMZ_CREDENTIAL)=\(accessKeyId)%2F20230724%2F\(region)%2F\(SignerConstants.SERVICE)%2F\(SignerConstants.AWS4_REQUEST_TYPE)&\(SignerConstants.X_AMZ_DATE)=20230724T080702Z&\(SignerConstants.X_AMZ_EXPIRES)=299&\(SignerConstants.X_AMZ_SIGNED_HEADERS)=\(SignerConstants.SIGNED_HEADERS)&\(SignerConstants.X_AMZ_SIGNATURE)=0bbef329f0d9d3e68635f7b844ac684c7764a0c228ca013232d935c111b9a370"
+        let expected: URL = URL(string: expectedString)!
+
+        let actual = try Signer.sign(request: URLRequest(url: uriToSign), credentials: AWSCredentials(accessKey: accessKeyId, secretKey: secretKeyId, sessionToken: sessionToken), region: region, currentDate: Date(timeIntervalSince1970: dateSecs))
+
+        XCTAssertEqual(expected, actual.url!)
+    }
+    
+    func test_when_signViewerURLWithTemporaryCredentials_then_returnValidSignedURL() throws {
+        let viewerURIToSignProtocolAndHost: String = "wss://v-a1b2c3d4.kinesisvideo.us-west-2.amazonaws.com"
+        let uriToSign: URL = URL(string: "\(viewerURIToSignProtocolAndHost)?X-Amz-ChannelARN=arn:aws:kinesisvideo:us-west-2:123456789012:channel/demo-channel/1234567890123&X-Amz-ClientId=d7d1c6e2-9cb0-4d61-bea9-ecb3d3816557")!
+        let accessKeyId: String = "AKIAIOSFODNN7EXAMPLE"
+        let secretKeyId: String = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        let sessionToken: String = "AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+FvwqnKwRcOIfrRh3c/LTo6UDdyJwOOvEVPvLXCrrrUtdnniCEXAMPLE/IvU1dYUg2RVAJBanLiHb4IgRmpRV3zrkuWJOgQs8IZZaIv2BXIa2R4OlgkBN9bkUDNCJiBeb/AXlzBBko7b15fjrBs2+cTQtpZ3CYWFXG8C5zqx37wnOE49mRl/+OtkIKGO7fAE"
+        let region: String = "us-west-2"
+        let dateSecs: TimeInterval = 1690186022.958
+
+        let expected: URLRequest = URLRequest(url: URL(string: "\(viewerURIToSignProtocolAndHost)/?\(SignerConstants.X_AMZ_ALGORITHM)=\(SignerConstants.ALGORITHM_AWS4_HMAC_SHA_256)&X-Amz-ChannelARN=arn%3Aaws%3Akinesisvideo%3Aus-west-2%3A123456789012%3Achannel%2Fdemo-channel%2F1234567890123&X-Amz-ClientId=d7d1c6e2-9cb0-4d61-bea9-ecb3d3816557&\(SignerConstants.X_AMZ_CREDENTIAL)=\(accessKeyId)%2F20230724%2F\(region)%2F\(SignerConstants.SERVICE)%2F\(SignerConstants.AWS4_REQUEST_TYPE)&\(SignerConstants.X_AMZ_DATE)=20230724T080702Z&\(SignerConstants.X_AMZ_EXPIRES)=299&\(SignerConstants.X_AMZ_SECURITY_TOKEN)=AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT%2BFvwqnKwRcOIfrRh3c%2FLTo6UDdyJwOOvEVPvLXCrrrUtdnniCEXAMPLE%2FIvU1dYUg2RVAJBanLiHb4IgRmpRV3zrkuWJOgQs8IZZaIv2BXIa2R4OlgkBN9bkUDNCJiBeb%2FAXlzBBko7b15fjrBs2%2BcTQtpZ3CYWFXG8C5zqx37wnOE49mRl%2F%2BOtkIKGO7fAE&\(SignerConstants.X_AMZ_SIGNED_HEADERS)=\(SignerConstants.SIGNED_HEADERS)&\(SignerConstants.X_AMZ_SIGNATURE)=77ea5ff8ede2e22aa268a3a068f1ad3a5d92f0fa8a427579f9e6376e97139761")!)
+
+        let actual: URLRequest = try Signer.sign(
+            request: URLRequest(url: uriToSign),
+            credentials: AWSCredentials(accessKey: accessKeyId, secretKey: secretKeyId, sessionToken: sessionToken),
+            region: region,
+            currentDate: Date(timeIntervalSince1970: dateSecs)
+        )
+
+        XCTAssertEqual(expected, actual)
+
+    }
+    
+    func test_when_signViewerURLWithLongTermCredentials_then_returnValidSignedURL() throws {
+        let viewerURIToSignProtocolAndHost = "wss://v-a1b2c3d4.kinesisvideo.us-west-2.amazonaws.com";
+        let uriToSign = URL(string: "\(viewerURIToSignProtocolAndHost)?X-Amz-ChannelARN=arn:aws:kinesisvideo:us-west-2:123456789012:channel/demo-channel/1234567890123&X-Amz-ClientId=d7d1c6e2-9cb0-4d61-bea9-ecb3d3816557")!
+        let accessKeyId = "AKIAIOSFODJJ7EXAMPLE";
+        let secretKeyId = "wJalrXUtnFEMI/K7MDENG/bPxQQiCYEXAMPLEKEY";
+        let sessionToken = "";
+        let region = "us-west-2";
+        let dateSecs: TimeInterval = 1690186022.958;
+        
+        let expected = URLRequest(url: URL(string: viewerURIToSignProtocolAndHost + "/?" + SignerConstants.X_AMZ_ALGORITHM + "=" + SignerConstants.ALGORITHM_AWS4_HMAC_SHA_256 + "&X-Amz-ChannelARN=arn%3Aaws%3Akinesisvideo%3Aus-west-2%3A123456789012%3Achannel%2Fdemo-channel%2F1234567890123&X-Amz-ClientId=d7d1c6e2-9cb0-4d61-bea9-ecb3d3816557&" + SignerConstants.X_AMZ_CREDENTIAL + "=" + accessKeyId + "%2F20230724%2F" + region + "%2F" + SignerConstants.SERVICE + "%2F" + SignerConstants.AWS4_REQUEST_TYPE + "&" + SignerConstants.X_AMZ_DATE + "=20230724T080702Z&" + SignerConstants.X_AMZ_EXPIRES + "=299&" + SignerConstants.X_AMZ_SIGNED_HEADERS + "=" + SignerConstants.SIGNED_HEADERS + "&" + SignerConstants.X_AMZ_SIGNATURE + "=cea541f699dc51bc53a55590ce817e63cc06fac2bdef4696b63e0889eb448f0b")!)
+        
+        let actual = try Signer.sign(request: URLRequest(url: uriToSign), credentials: AWSCredentials(accessKey: accessKeyId, secretKey: secretKeyId, sessionToken: sessionToken), region: region, currentDate: Date(timeIntervalSince1970: dateSecs))
+        
+        XCTAssertEqual(expected, actual);
+    }
+    
+    func test_when_getCanonicalRequestWithQueryParameters_then_validCanonicalQueryStringReturned() {
+        let canonicalResultExpected: String = """
+            \(SignerConstants.METHOD)
+            /
+            Param1=value1&Param2=value2
+            host:example.amazonaws.com
+            
+            \(SignerConstants.SIGNED_HEADERS)
+            e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            """
+        
+        let uri: URL = URL(string: "http://example.amazonaws.com/")!
+        
+        // Add query parameters out of order to ensure that the resulting query parameters are in alphabetical order
+        var queryParamsMap: [(String, String)] = [("Param2", "value2"), ("Param1", "value1")]
+        let canonicalQueryString: String = Signer.getCanonicalizedQueryString(&queryParamsMap)
+        
+        let canonicalQuerystring: String = Signer.buildCanonicalRequest(url: uri, canonicalQueryString: canonicalQueryString)
+        
+        XCTAssertEqual(canonicalResultExpected, canonicalQuerystring)
+    }
+    
+    func test_when_buildQueryParamsMapWithLongTermCredentials_then_mapContainsCorrectParametersAndDoesNotContainXAmzSecurityToken() throws {
+        let testUri: URL = URL(string: "wss://v-a1b2c3d4.kinesisvideo.us-west-2.amazonaws.com?X-Amz-ChannelARN=arn:aws:kinesisvideo:us-west-2:123456789012:channel/demo-channel/1234567890123")!
+        let testAccessKeyId: String = "AKIDEXAMPLE"
+        let testSessionToken: String? = nil // since session token is not provided, we expect X-Amz-Security-Token to not be present in the map
+        let testRegion: String = "us-west-2"
+        let testTimestamp: String = "20230724T000000Z"
+        let testDatestamp: String = "20230724"
+
+        var expectedQueryParams: [(String, String)] = []
+        expectedQueryParams.append((SignerConstants.X_AMZ_ALGORITHM, SignerConstants.ALGORITHM_AWS4_HMAC_SHA_256))
+        expectedQueryParams.append((SignerConstants.X_AMZ_CREDENTIAL,  "\(testAccessKeyId)%2F\(testDatestamp)%2F\(testRegion)%2F\(SignerConstants.SERVICE)%2F\(SignerConstants.AWS4_REQUEST_TYPE)"))
+        expectedQueryParams.append((SignerConstants.X_AMZ_DATE, testTimestamp))
+        expectedQueryParams.append((SignerConstants.X_AMZ_EXPIRES, "299"))
+        expectedQueryParams.append((SignerConstants.X_AMZ_SIGNED_HEADERS, SignerConstants.SIGNED_HEADERS))
+        expectedQueryParams.append(("X-Amz-ChannelARN",  "arn%3Aaws%3Akinesisvideo%3Aus-west-2%3A123456789012%3Achannel%2Fdemo-channel%2F1234567890123"))
+
+        let actualQueryParams: [(String, String)] = try Signer.buildQueryParamsMap(url: testUri, accessKey: testAccessKeyId, sessionToken: testSessionToken, region: testRegion, amzDate: testTimestamp, dateStamp: testDatestamp)
+
+        XCTAssertTrue(expectedQueryParams.elementsEqual(actualQueryParams, by: ==))
+    }
+    
+    func test_when_buildQueryParamsMapWithTemporaryCredentials_then_mapContainsCorrectParameters() throws {
+        let testUri: URL = URL(string: "wss://v-a1b2c3d4.kinesisvideo.us-west-2.amazonaws.com?X-Amz-ChannelARN=arn:aws:kinesisvideo:us-west-2:123456789012:channel/demo-channel/1234567890123&X-Amz-ClientId=d7d1c6e2-9cb0-4d61-bea9-ecb3d3816557")!
+        let testAccessKeyId: String = "AKIDEXAMPLE"
+        let testSessionToken: String = "SSEXAMPLE"
+        let testRegion: String = "us-west-2"
+        let testTimestamp: String = "20230724T000000Z"
+        let testDatestamp: String = "20230724"
+
+        var expectedQueryParams: [(String, String)] = []
+        expectedQueryParams.append((SignerConstants.X_AMZ_ALGORITHM, SignerConstants.ALGORITHM_AWS4_HMAC_SHA_256))
+        expectedQueryParams.append((SignerConstants.X_AMZ_CREDENTIAL,  "\(testAccessKeyId)%2F\(testDatestamp)%2F\(testRegion)%2F\(SignerConstants.SERVICE)%2F\(SignerConstants.AWS4_REQUEST_TYPE)"))
+        expectedQueryParams.append((SignerConstants.X_AMZ_DATE, testTimestamp))
+        expectedQueryParams.append((SignerConstants.X_AMZ_EXPIRES, "299"))
+        expectedQueryParams.append((SignerConstants.X_AMZ_SIGNED_HEADERS, SignerConstants.SIGNED_HEADERS))
+        expectedQueryParams.append((SignerConstants.X_AMZ_SECURITY_TOKEN, "SSEXAMPLE"))
+        expectedQueryParams.append(("X-Amz-ChannelARN",  "arn%3Aaws%3Akinesisvideo%3Aus-west-2%3A123456789012%3Achannel%2Fdemo-channel%2F1234567890123"))
+        expectedQueryParams.append(("X-Amz-ClientId", "d7d1c6e2-9cb0-4d61-bea9-ecb3d3816557"))
+
+        let actualQueryParams: [(String, String)] = try Signer.buildQueryParamsMap(url: testUri, accessKey: testAccessKeyId, sessionToken: testSessionToken, region: testRegion, amzDate: testTimestamp, dateStamp: testDatestamp)
+
+        XCTAssertTrue(expectedQueryParams.elementsEqual(actualQueryParams, by: ==))
+    }
+    
+    func test_when_buildQueryParamsMapWithInvalidQueryParameter_then_errorThrown() {
+        // The query parameter is malformed because it contains more than one `=` sign. `=` signs are used
+        // to seperate the key from the value.
+        let malformedQueryParameterString: String = "\(SignerConstants.X_AMZ_SECURITY_TOKEN)=IQoJb3JpZ2luX2VjEKj//////////wEaCXVzLWVhc3QtMSJIMEYCIQCTthgQ/TPulBrPMhU5h/UtUse+BpwUab+C9btFV3i39AIhAJVcIPQL2fOnawG6SG+iedPPxqiGyOJQxFdbtkOsr1KVKp4CCBEQAhoMNzkwNjc1MTI4OTQxIgx/dYEfFDWltpFKMiYq+wEJJf5Z0J05YV4uShxtJIJU3JiFQzSimB7i3uyyli3RZ4Crdk4M7jmYi3j10u//rmWh4tj07wP6UiExrQqge/dLG1l2/mI+npSLhpSOLPQpXZ8P3wj05oZdki3gc0HfIyOVXYscMHWt51CLG6mex46rl6gAVhPIvfgHKrvu+a9lEsqsKgZgDSx/vxU3jJORXde+OoOOh6H1kJbh1Z8YjcZF4gddiAtr+lDAbkP+wfkvx/NXNdX4gvOn2A1q04rwmAqajXnRwrAFfdsTgyuVgtwLzLetgLROU33V9HzlmmB8cgqSfOmckRLYY2oQhjAR9u7miCSgpKlExiKNAzCcnqarBjqcASd000CV05xssboLehIZ76mDRRuLIjAgdT8kghGoCZ7LZsSwtUuyMKXf50g/QCYHoFgJKkMAVKykZArxdwbfuszo/+JVOHTu8ZuXUYjhDHHrImdMdmTd+fIzpjJUmqVbi2MtNKZuGMwJtk5/Yqn9BbnpIAhx3JU7R2TMopaae6ISQH9vW8Qunq4KIIGCvEznB0v8hf9ot4a6po3B/A=="
+        let testUri: URL = URL(string: "wss://v-a1b2c3d4.kinesisvideo.us-west-2.amazonaws.com?\(malformedQueryParameterString)")!
+        let testAccessKeyId: String = "AKIDEXAMPLE"
+        let testSessionToken: String? = nil
+        let testRegion: String = "us-west-2"
+        let testTimestamp: String = "20230724T000000Z"
+        let testDatestamp: String = "20230724"
+
+        XCTAssertThrowsError(try Signer.buildQueryParamsMap(url: testUri, accessKey: testAccessKeyId, sessionToken: testSessionToken, region: testRegion, amzDate: testTimestamp, dateStamp: testDatestamp)) { error in
+            
+            guard case let SignerError.illegalArgument(message) = error else {
+                XCTFail("Unexpected error type thrown")
+                return
+            }
+            
+            XCTAssertTrue(message.contains(malformedQueryParameterString), "The error message \"\(message)\" should contain \"\(malformedQueryParameterString)\"!")
+        }
+    }
+    
+    func test_when_buildQueryParamsMapWithEmptyQueryParameter_then_errorThrown() {
+        // The query parameter is malformed because it contains more than one `=` sign. `=` signs are used
+        // to seperate the key from the value.
+        let malformedQueryParameterString: String = "X-Amz-ChannelARN=arn:aws:kinesisvideo:us-west-2:123456789012:channel/demo-channel/1234567890123&"
+        let testUri: URL = URL(string: "wss://v-a1b2c3d4.kinesisvideo.us-west-2.amazonaws.com?\(malformedQueryParameterString)")!
+        let testAccessKeyId: String = "AKIDEXAMPLE"
+        let testSessionToken: String? = nil
+        let testRegion: String = "us-west-2"
+        let testTimestamp: String = "20230724T000000Z"
+        let testDatestamp: String = "20230724"
+
+        XCTAssertThrowsError(try Signer.buildQueryParamsMap(url: testUri, accessKey: testAccessKeyId, sessionToken: testSessionToken, region: testRegion, amzDate: testTimestamp, dateStamp: testDatestamp)) { error in
+            
+            guard case let SignerError.illegalArgument(message) = error else {
+                XCTFail("Unexpected error type thrown")
+                return
+            }
+            
+            XCTAssertTrue(message.lowercased().contains("malformed"), "The error message \"\(message)\" should contain \"malformed\"!")
+        }
+    }
+    
+    func test_when_signStringWithExampleInputs_then_validStringToSignIsReturned() {
+        let credentialScope = "AKIDEXAMPLE/20150830/us-east-1/service/aws4_request"
+        let requestDate = "20150830T123600Z"
+        let canonicalRequest = """
+            \(SignerConstants.METHOD)
+            /
+            Param1=value1&Param2=value2
+            host:example.amazonaws.com
+            x-amz-date:20150830T123600Z
+            
+            \(SignerConstants.SIGNED_HEADERS);x-amz-date
+            e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            """
+        
+        let expected = """
+            AWS4-HMAC-SHA256
+            20150830T123600Z
+            AKIDEXAMPLE/20150830/us-east-1/service/\(SignerConstants.AWS4_REQUEST_TYPE)
+            816cd5b414d056048ba4f7c5386d6e0533120fb1fcfa93762cf0fc39e2cf19e0
+            """
+        
+        let actual = Signer.signString(canonicalRequest: canonicalRequest, amzDate: requestDate, credentialScope: credentialScope)
+        
+        XCTAssertEqual(expected, actual)
+    }
+    
+    func test_when_getSignatureKeyWithStringToSign_then_validSignatureKeyReturned() {
+        let stringToSign: String = """
+            \(SignerConstants.ALGORITHM_AWS4_HMAC_SHA_256)
+            20150830T123600Z
+            20150830/us-east-1/iam/\(SignerConstants.AWS4_REQUEST_TYPE)
+            f536975d06c0309214f805bb90ccff089219ecd68b2577efef23edd43b7e1a59
+            """
+        
+        let signatureKeyBytes: Data = Signer.getSignatureKey(key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+                                                             dateStamp: "20150830",
+                                                             regionName: "us-east-1",
+                                                             service: "iam")
+        
+        let expectedSignature: String = "c4afb1cc5771d871763a393e44b703571b55cc28424d1a5e86da6ed3c154a4b9"
+        XCTAssertEqual(expectedSignature, signatureKeyBytes.hexString)
+        
+        let expectedSignatureString: String = "5d672d79c15b13162d9279b0855cfba6789a8edb4c82c400e06b5924a6f2b5d7"
+        XCTAssertEqual(expectedSignatureString, Signer.hmacSHA256(stringToSign, key: signatureKeyBytes).hexString)
+    }
+    
+    func test_when_urlEncodeStringWithSpecialCharacters_then_specialCharactersAreURLEncoded() {
+        let exampleArn: String = "arn:aws:kinesisvideo:us-west-2:123456789012:channel/demo-channel/1234567890123";
+        
+        let expected: String = "arn%3Aaws%3Akinesisvideo%3Aus-west-2%3A123456789012%3Achannel%2Fdemo-channel%2F1234567890123";
+        
+        let actual: String = Signer.urlEncode(exampleArn);
+        
+        XCTAssertEqual(expected, actual);
+    }
+    
+    
+    func test_when_createCredentialScope_then_validCredentialScopeReturned() {
+        let expected: String = "20150930/us-west-2/kinesisvideo/aws4_request"
+        
+        let actual: String = Signer.buildCredentialScope(region: "us-west-2", dateStamp: "20150930")
+        
+        XCTAssertEqual(expected, actual)
+    }
+    
+    func test_when_hmacSha256GivenKeyAndData_then_correctSignatureIsReturned() {
+        let testKey: Data = "testKey".data(using: .utf8)!
+        let testData: String = "testData123"
+        let expectedHex: String = "f8117085c5b8be75d01ce86d16d04e90fedfc4be4668fe75d39e72c92da45568"
+        
+        let actualResult: String = Signer.hmacSHA256(testData, key: testKey).hexString
+        
+        XCTAssertEqual(expectedHex, actualResult)
+    }
+    
+    struct TimeAndDateParameters {
+        let parameter: TimeInterval
+        let expectedOutput: String
+    }
+    
+    let sourceFor_when_getTimeStampAroundMidnightUTC_then_dateAndTimeReturnedIsCorrectAndFormattedCorrectly: [TimeAndDateParameters] = [
+        // 1689984000000 = Saturday, July 22, 2023 12:00:00.000 AM (UTC)
+        TimeAndDateParameters(parameter: 1689984000, expectedOutput: "20230722T000000Z"),
+        // 1689983999999 = Friday, July 21, 2023 11:59:59.999 AM (UTC)
+        TimeAndDateParameters(parameter: 1689983999.999, expectedOutput: "20230721T235959Z"),
+    ]
+    
+    func test_when_getTimeStampAroundMidnightUTC_then_dateAndTimeReturnedIsCorrectAndFormattedCorrectly() {
+        for data in sourceFor_when_getTimeStampAroundMidnightUTC_then_dateAndTimeReturnedIsCorrectAndFormattedCorrectly {
+            perform_when_getTimeStampAroundMidnightUTC_then_dateAndTimeReturnedIsCorrectAndFormattedCorrectly(data)
+        }
+    }
+    
+    func perform_when_getTimeStampAroundMidnightUTC_then_dateAndTimeReturnedIsCorrectAndFormattedCorrectly(_ data: TimeAndDateParameters) {
+        let expectedTimeStamp = data.expectedOutput
+        let actualTimeStamp = Signer.getTimeStamp(Date(timeIntervalSince1970: data.parameter))
+        
+        XCTAssertEqual(expectedTimeStamp, actualTimeStamp)
+    }
+    
+    let sourceFor_when_getDateStampAroundMidnightUTC_then_dateReturnedIsCorrectAndFormattedCorrectly: [TimeAndDateParameters] = [
+        // 1689984000000 = Saturday, July 22, 2023 12:00:00.000 AM (UTC)
+        TimeAndDateParameters(parameter: 1689984000, expectedOutput: "20230722"),
+        // 1689983999999 = Friday, July 21, 2023 11:59:59.999 AM (UTC)
+        TimeAndDateParameters(parameter: 1689983999.999, expectedOutput: "20230721"),
+    ]
+    
+    func test_when_getDateStampAroundMidnightUTC_then_dateReturnedIsCorrectAndFormattedCorrectly() {
+        for data in sourceFor_when_getDateStampAroundMidnightUTC_then_dateReturnedIsCorrectAndFormattedCorrectly {
+            perform_when_getDateStampAroundMidnightUTC_then_dateReturnedIsCorrectAndFormattedCorrectly(data)
+        }
+    }
+    
+    func perform_when_getDateStampAroundMidnightUTC_then_dateReturnedIsCorrectAndFormattedCorrectly(_ data: TimeAndDateParameters) {
+        let expectedDateStamp = data.expectedOutput
+        let actualDateStamp = Signer.getDateStamp(Date(timeIntervalSince1970: data.parameter))
+        
+        XCTAssertEqual(expectedDateStamp, actualDateStamp)
+    }
+    
+}

--- a/sigv4-signing/swift/sigv4/Sigv4Tests/Sigv4Tests.xctestplan
+++ b/sigv4-signing/swift/sigv4/Sigv4Tests/Sigv4Tests.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "FDBAD029-CC6E-49D6-8F92-0F5AED95266B",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:sigv4.xcodeproj",
+        "identifier" : "8EFDD97D2B17CE9600562782",
+        "name" : "Sigv4UnitTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/sigv4-signing/swift/sigv4/sigv4.xcodeproj/project.pbxproj
+++ b/sigv4-signing/swift/sigv4/sigv4.xcodeproj/project.pbxproj
@@ -1,0 +1,737 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		09083FC88B1F7BA58333756B /* libPods-Sigv4.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B15D2B55CF19615BAEEEC59D /* libPods-Sigv4.a */; };
+		0ED46C3EE032426D68F087FD /* libPods-Sigv4CLI.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CC46268F55EF8EABBA926347 /* libPods-Sigv4CLI.a */; };
+		6B6698608B3FC114B52F0E19 /* libPods-Sigv4Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = AA1589830B263ABE14263276 /* libPods-Sigv4Tests.a */; };
+		8EFDD95A2B17CCEE00562782 /* sigv4Framework.docc in Sources */ = {isa = PBXBuildFile; fileRef = 8EFDD9592B17CCEE00562782 /* sigv4Framework.docc */; };
+		8EFDD9662B17CCEE00562782 /* sigv4Framework.h in Headers */ = {isa = PBXBuildFile; fileRef = 8EFDD9582B17CCEE00562782 /* sigv4Framework.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8EFDD96D2B17CD1200562782 /* Signer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E0942CC2B17A3BA00AD2F20 /* Signer.swift */; };
+		8EFDD9762B17CDF000562782 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EFDD9752B17CDF000562782 /* main.swift */; };
+		8EFDD9812B17CE9600562782 /* Sigv4Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EFDD9802B17CE9600562782 /* Sigv4Tests.swift */; };
+		8EFDD9822B17CE9600562782 /* Sigv4.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8EFDD9562B17CCEE00562782 /* Sigv4.framework */; };
+		8EFDD98E2B17D02100562782 /* Sigv4.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8EFDD9562B17CCEE00562782 /* Sigv4.framework */; };
+		8EFDD98F2B17D02100562782 /* Sigv4.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8EFDD9562B17CCEE00562782 /* Sigv4.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8EFDD99B2B18054C00562782 /* SignerConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EFDD99A2B18054C00562782 /* SignerConstants.swift */; };
+		A5591C5BC5BF23B4D81FEDF9 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		8EFDD9832B17CE9600562782 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8E17A51F2B1724160096E2BF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8EFDD9552B17CCEE00562782;
+			remoteInfo = Sigv4;
+		};
+		8EFDD9902B17D02100562782 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8E17A51F2B1724160096E2BF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8EFDD9552B17CCEE00562782;
+			remoteInfo = Sigv4;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		8EFDD9712B17CDF000562782 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		8EFDD9932B17D02100562782 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				8EFDD98F2B17D02100562782 /* Sigv4.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		485383BAAC1268DF4FE065DB /* libPods-unittests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-unittests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		56448EF0EA7CA04F0630BC43 /* Pods-Sigv4.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sigv4.debug.xcconfig"; path = "Target Support Files/Pods-Sigv4/Pods-Sigv4.debug.xcconfig"; sourceTree = "<group>"; };
+		60DD5F2B9CF52110BF8E518F /* Pods-Sigv4CLI.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sigv4CLI.release.xcconfig"; path = "Target Support Files/Pods-Sigv4CLI/Pods-Sigv4CLI.release.xcconfig"; sourceTree = "<group>"; };
+		6A62C2C53408BB73ECF2A56E /* Pods-sigv4.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-sigv4.release.xcconfig"; path = "Target Support Files/Pods-sigv4/Pods-sigv4.release.xcconfig"; sourceTree = "<group>"; };
+		72F853B4DAF9BA6E325ABC77 /* Pods-unittests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-unittests.debug.xcconfig"; path = "Target Support Files/Pods-unittests/Pods-unittests.debug.xcconfig"; sourceTree = "<group>"; };
+		7AE43BCB2953B1E772443EE1 /* Pods-Sigv4Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sigv4Tests.release.xcconfig"; path = "Target Support Files/Pods-Sigv4Tests/Pods-Sigv4Tests.release.xcconfig"; sourceTree = "<group>"; };
+		8E0942CC2B17A3BA00AD2F20 /* Signer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Signer.swift; sourceTree = "<group>"; };
+		8E0942E62B17CC3300AD2F20 /* libStarscream.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libStarscream.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		8EB27C612B3B777A00D283FB /* Sigv4Tests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = Sigv4Tests.xctestplan; sourceTree = "<group>"; };
+		8EFDD9562B17CCEE00562782 /* Sigv4.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Sigv4.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8EFDD9582B17CCEE00562782 /* sigv4Framework.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sigv4Framework.h; sourceTree = "<group>"; };
+		8EFDD9592B17CCEE00562782 /* sigv4Framework.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = sigv4Framework.docc; sourceTree = "<group>"; };
+		8EFDD9732B17CDF000562782 /* Sigv4CLI */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = Sigv4CLI; sourceTree = BUILT_PRODUCTS_DIR; };
+		8EFDD9752B17CDF000562782 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		8EFDD97E2B17CE9600562782 /* Sigv4UnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Sigv4UnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		8EFDD9802B17CE9600562782 /* Sigv4Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sigv4Tests.swift; sourceTree = "<group>"; };
+		8EFDD9942B17D02800562782 /* libStarscream.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libStarscream.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		8EFDD9972B17D0FC00562782 /* libStarscream.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libStarscream.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		8EFDD99A2B18054C00562782 /* SignerConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignerConstants.swift; sourceTree = "<group>"; };
+		8F03DFB8782B68BF6D1D42BB /* libPods-sigv4.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-sigv4.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		94025248DC396456A363D6F6 /* Pods-sigv4UnitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-sigv4UnitTests.release.xcconfig"; path = "Target Support Files/Pods-sigv4UnitTests/Pods-sigv4UnitTests.release.xcconfig"; sourceTree = "<group>"; };
+		AA1589830B263ABE14263276 /* libPods-Sigv4Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Sigv4Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		ADA507827CE490E9267B6B1B /* Pods-Sigv4Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sigv4Tests.debug.xcconfig"; path = "Target Support Files/Pods-Sigv4Tests/Pods-Sigv4Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		B15D2B55CF19615BAEEEC59D /* libPods-Sigv4.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Sigv4.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B54FE814A42E26140AE263AC /* Pods-sigv4UnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-sigv4UnitTests.debug.xcconfig"; path = "Target Support Files/Pods-sigv4UnitTests/Pods-sigv4UnitTests.debug.xcconfig"; sourceTree = "<group>"; };
+		BB5107278BA7A82F6032C4EB /* Pods-unittests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-unittests.release.xcconfig"; path = "Target Support Files/Pods-unittests/Pods-unittests.release.xcconfig"; sourceTree = "<group>"; };
+		C21B8E5BFF9F9107BE793EF8 /* Pods-sigv4.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-sigv4.debug.xcconfig"; path = "Target Support Files/Pods-sigv4/Pods-sigv4.debug.xcconfig"; sourceTree = "<group>"; };
+		CC46268F55EF8EABBA926347 /* libPods-Sigv4CLI.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Sigv4CLI.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E8DC43FB2D578380D0A43B0C /* Pods-Sigv4.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sigv4.release.xcconfig"; path = "Target Support Files/Pods-Sigv4/Pods-Sigv4.release.xcconfig"; sourceTree = "<group>"; };
+		EF3BE3B69FEA4F26D6972487 /* libPods-sigv4UnitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-sigv4UnitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F996422850E239BDAEA7DA3D /* Pods-Sigv4CLI.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sigv4CLI.debug.xcconfig"; path = "Target Support Files/Pods-Sigv4CLI/Pods-Sigv4CLI.debug.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		8EFDD9532B17CCEE00562782 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A5591C5BC5BF23B4D81FEDF9 /* (null) in Frameworks */,
+				09083FC88B1F7BA58333756B /* libPods-Sigv4.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8EFDD9702B17CDF000562782 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8EFDD98E2B17D02100562782 /* Sigv4.framework in Frameworks */,
+				0ED46C3EE032426D68F087FD /* libPods-Sigv4CLI.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8EFDD97B2B17CE9600562782 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8EFDD9822B17CE9600562782 /* Sigv4.framework in Frameworks */,
+				6B6698608B3FC114B52F0E19 /* libPods-Sigv4Tests.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		8625C9759CB23C8FDE4373F2 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				C21B8E5BFF9F9107BE793EF8 /* Pods-sigv4.debug.xcconfig */,
+				6A62C2C53408BB73ECF2A56E /* Pods-sigv4.release.xcconfig */,
+				72F853B4DAF9BA6E325ABC77 /* Pods-unittests.debug.xcconfig */,
+				BB5107278BA7A82F6032C4EB /* Pods-unittests.release.xcconfig */,
+				B54FE814A42E26140AE263AC /* Pods-sigv4UnitTests.debug.xcconfig */,
+				94025248DC396456A363D6F6 /* Pods-sigv4UnitTests.release.xcconfig */,
+				56448EF0EA7CA04F0630BC43 /* Pods-Sigv4.debug.xcconfig */,
+				E8DC43FB2D578380D0A43B0C /* Pods-Sigv4.release.xcconfig */,
+				ADA507827CE490E9267B6B1B /* Pods-Sigv4Tests.debug.xcconfig */,
+				7AE43BCB2953B1E772443EE1 /* Pods-Sigv4Tests.release.xcconfig */,
+				F996422850E239BDAEA7DA3D /* Pods-Sigv4CLI.debug.xcconfig */,
+				60DD5F2B9CF52110BF8E518F /* Pods-Sigv4CLI.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
+		8E17A51E2B1724160096E2BF = {
+			isa = PBXGroup;
+			children = (
+				8EFDD9572B17CCEE00562782 /* Sigv4Signer */,
+				8EFDD9742B17CDF000562782 /* Sigv4CLI */,
+				8EFDD97F2B17CE9600562782 /* Sigv4Tests */,
+				8E17A5282B1724160096E2BF /* Products */,
+				8625C9759CB23C8FDE4373F2 /* Pods */,
+				93C129FDF6A6D6427F632239 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		8E17A5282B1724160096E2BF /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				8EFDD9562B17CCEE00562782 /* Sigv4.framework */,
+				8EFDD9732B17CDF000562782 /* Sigv4CLI */,
+				8EFDD97E2B17CE9600562782 /* Sigv4UnitTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		8EFDD9572B17CCEE00562782 /* Sigv4Signer */ = {
+			isa = PBXGroup;
+			children = (
+				8E0942CC2B17A3BA00AD2F20 /* Signer.swift */,
+				8EFDD9582B17CCEE00562782 /* sigv4Framework.h */,
+				8EFDD9592B17CCEE00562782 /* sigv4Framework.docc */,
+				8EFDD99A2B18054C00562782 /* SignerConstants.swift */,
+			);
+			path = Sigv4Signer;
+			sourceTree = "<group>";
+		};
+		8EFDD9742B17CDF000562782 /* Sigv4CLI */ = {
+			isa = PBXGroup;
+			children = (
+				8EFDD9752B17CDF000562782 /* main.swift */,
+			);
+			path = Sigv4CLI;
+			sourceTree = "<group>";
+		};
+		8EFDD97F2B17CE9600562782 /* Sigv4Tests */ = {
+			isa = PBXGroup;
+			children = (
+				8EFDD9802B17CE9600562782 /* Sigv4Tests.swift */,
+				8EB27C612B3B777A00D283FB /* Sigv4Tests.xctestplan */,
+			);
+			path = Sigv4Tests;
+			sourceTree = "<group>";
+		};
+		93C129FDF6A6D6427F632239 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				8EFDD9972B17D0FC00562782 /* libStarscream.a */,
+				8EFDD9942B17D02800562782 /* libStarscream.a */,
+				8E0942E62B17CC3300AD2F20 /* libStarscream.a */,
+				8F03DFB8782B68BF6D1D42BB /* libPods-sigv4.a */,
+				485383BAAC1268DF4FE065DB /* libPods-unittests.a */,
+				EF3BE3B69FEA4F26D6972487 /* libPods-sigv4UnitTests.a */,
+				B15D2B55CF19615BAEEEC59D /* libPods-Sigv4.a */,
+				AA1589830B263ABE14263276 /* libPods-Sigv4Tests.a */,
+				CC46268F55EF8EABBA926347 /* libPods-Sigv4CLI.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		8EFDD9512B17CCEE00562782 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8EFDD9662B17CCEE00562782 /* sigv4Framework.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		8EFDD9552B17CCEE00562782 /* Sigv4 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8EFDD9672B17CCEE00562782 /* Build configuration list for PBXNativeTarget "Sigv4" */;
+			buildPhases = (
+				6F1AD27F9BC5FF1517E632B9 /* [CP] Check Pods Manifest.lock */,
+				8EFDD9512B17CCEE00562782 /* Headers */,
+				8EFDD9522B17CCEE00562782 /* Sources */,
+				8EFDD9532B17CCEE00562782 /* Frameworks */,
+				8EFDD9542B17CCEE00562782 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Sigv4;
+			productName = sigv4Framework;
+			productReference = 8EFDD9562B17CCEE00562782 /* Sigv4.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		8EFDD9722B17CDF000562782 /* Sigv4CLI */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8EFDD9772B17CDF000562782 /* Build configuration list for PBXNativeTarget "Sigv4CLI" */;
+			buildPhases = (
+				C25375CD1519A476DDA50228 /* [CP] Check Pods Manifest.lock */,
+				8EFDD96F2B17CDF000562782 /* Sources */,
+				8EFDD9702B17CDF000562782 /* Frameworks */,
+				8EFDD9712B17CDF000562782 /* CopyFiles */,
+				8EFDD9932B17D02100562782 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				8EFDD9912B17D02100562782 /* PBXTargetDependency */,
+			);
+			name = Sigv4CLI;
+			productName = sigv4CLI;
+			productReference = 8EFDD9732B17CDF000562782 /* Sigv4CLI */;
+			productType = "com.apple.product-type.tool";
+		};
+		8EFDD97D2B17CE9600562782 /* Sigv4UnitTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8EFDD9852B17CE9600562782 /* Build configuration list for PBXNativeTarget "Sigv4UnitTests" */;
+			buildPhases = (
+				15AD3105406B56A54631D8B9 /* [CP] Check Pods Manifest.lock */,
+				8EFDD97A2B17CE9600562782 /* Sources */,
+				8EFDD97B2B17CE9600562782 /* Frameworks */,
+				8EFDD97C2B17CE9600562782 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				8EFDD9842B17CE9600562782 /* PBXTargetDependency */,
+			);
+			name = Sigv4UnitTests;
+			productName = Sigv4Tests;
+			productReference = 8EFDD97E2B17CE9600562782 /* Sigv4UnitTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		8E17A51F2B1724160096E2BF /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1500;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+					8EFDD9552B17CCEE00562782 = {
+						CreatedOnToolsVersion = 15.0;
+					};
+					8EFDD9722B17CDF000562782 = {
+						CreatedOnToolsVersion = 15.0;
+					};
+					8EFDD97D2B17CE9600562782 = {
+						CreatedOnToolsVersion = 15.0;
+					};
+				};
+			};
+			buildConfigurationList = 8E17A5222B1724160096E2BF /* Build configuration list for PBXProject "sigv4" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 8E17A51E2B1724160096E2BF;
+			productRefGroup = 8E17A5282B1724160096E2BF /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				8EFDD9552B17CCEE00562782 /* Sigv4 */,
+				8EFDD9722B17CDF000562782 /* Sigv4CLI */,
+				8EFDD97D2B17CE9600562782 /* Sigv4UnitTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		8EFDD9542B17CCEE00562782 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8EFDD97C2B17CE9600562782 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		15AD3105406B56A54631D8B9 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Sigv4Tests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		6F1AD27F9BC5FF1517E632B9 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Sigv4-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C25375CD1519A476DDA50228 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Sigv4CLI-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		8EFDD9522B17CCEE00562782 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8EFDD95A2B17CCEE00562782 /* sigv4Framework.docc in Sources */,
+				8EFDD99B2B18054C00562782 /* SignerConstants.swift in Sources */,
+				8EFDD96D2B17CD1200562782 /* Signer.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8EFDD96F2B17CDF000562782 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8EFDD9762B17CDF000562782 /* main.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8EFDD97A2B17CE9600562782 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8EFDD9812B17CE9600562782 /* Sigv4Tests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		8EFDD9842B17CE9600562782 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8EFDD9552B17CCEE00562782 /* Sigv4 */;
+			targetProxy = 8EFDD9832B17CE9600562782 /* PBXContainerItemProxy */;
+		};
+		8EFDD9912B17D02100562782 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8EFDD9552B17CCEE00562782 /* Sigv4 */;
+			targetProxy = 8EFDD9902B17D02100562782 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		8E17A52C2B1724160096E2BF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.5;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		8E17A52D2B1724160096E2BF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.5;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+			};
+			name = Release;
+		};
+		8EFDD9682B17CCEE00562782 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 56448EF0EA7CA04F0630BC43 /* Pods-Sigv4.debug.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.kinesisvideo.sigv4Framework;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		8EFDD9692B17CCEE00562782 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E8DC43FB2D578380D0A43B0C /* Pods-Sigv4.release.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.kinesisvideo.sigv4Framework;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		8EFDD9782B17CDF000562782 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = F996422850E239BDAEA7DA3D /* Pods-Sigv4CLI.debug.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		8EFDD9792B17CDF000562782 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 60DD5F2B9CF52110BF8E518F /* Pods-Sigv4CLI.release.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		8EFDD9862B17CE9600562782 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = ADA507827CE490E9267B6B1B /* Pods-Sigv4Tests.debug.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.kinesisvideo.Sigv4Tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		8EFDD9872B17CE9600562782 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7AE43BCB2953B1E772443EE1 /* Pods-Sigv4Tests.release.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.kinesisvideo.Sigv4Tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		8E17A5222B1724160096E2BF /* Build configuration list for PBXProject "sigv4" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8E17A52C2B1724160096E2BF /* Debug */,
+				8E17A52D2B1724160096E2BF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8EFDD9672B17CCEE00562782 /* Build configuration list for PBXNativeTarget "Sigv4" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8EFDD9682B17CCEE00562782 /* Debug */,
+				8EFDD9692B17CCEE00562782 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8EFDD9772B17CDF000562782 /* Build configuration list for PBXNativeTarget "Sigv4CLI" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8EFDD9782B17CDF000562782 /* Debug */,
+				8EFDD9792B17CDF000562782 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8EFDD9852B17CE9600562782 /* Build configuration list for PBXNativeTarget "Sigv4UnitTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8EFDD9862B17CE9600562782 /* Debug */,
+				8EFDD9872B17CE9600562782 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 8E17A51F2B1724160096E2BF /* Project object */;
+}

--- a/sigv4-signing/swift/sigv4/sigv4.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/sigv4-signing/swift/sigv4/sigv4.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/sigv4-signing/swift/sigv4/sigv4.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/sigv4-signing/swift/sigv4/sigv4.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/sigv4-signing/swift/sigv4/sigv4.xcodeproj/xcshareddata/xcschemes/sigv4.xcscheme
+++ b/sigv4-signing/swift/sigv4/sigv4.xcodeproj/xcshareddata/xcschemes/sigv4.xcscheme
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8EFDD9552B17CCEE00562782"
+               BuildableName = "Sigv4.framework"
+               BlueprintName = "Sigv4"
+               ReferencedContainer = "container:sigv4.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:../Sigv4.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:Sigv4Tests/Sigv4Tests.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8EFDD97D2B17CE9600562782"
+               BuildableName = "Sigv4UnitTests.xctest"
+               BlueprintName = "Sigv4UnitTests"
+               ReferencedContainer = "container:sigv4.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8EFDD9722B17CDF000562782"
+            BuildableName = "Sigv4CLI"
+            BlueprintName = "Sigv4CLI"
+            ReferencedContainer = "container:sigv4.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8EFDD9552B17CCEE00562782"
+            BuildableName = "Sigv4.framework"
+            BlueprintName = "Sigv4"
+            ReferencedContainer = "container:sigv4.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/sigv4-signing/swift/sigv4/sigv4.xcodeproj/xcshareddata/xcschemes/unittests.xcscheme
+++ b/sigv4-signing/swift/sigv4/sigv4.xcodeproj/xcshareddata/xcschemes/unittests.xcscheme
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "YES"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8E0942D12B17B85A00AD2F20"
+               BuildableName = "unittests.xctest"
+               BlueprintName = "unittests"
+               ReferencedContainer = "container:sigv4.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/sigv4-signing/swift/sigv4/sigv4.xcworkspace/contents.xcworkspacedata
+++ b/sigv4-signing/swift/sigv4/sigv4.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:sigv4.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/sigv4-signing/swift/sigv4/sigv4.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/sigv4-signing/swift/sigv4/sigv4.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/sigv4-signing/swift/sigv4/sigv4.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/sigv4-signing/swift/sigv4/sigv4.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>


### PR DESCRIPTION
*Description of changes:*
* Add Sigv4 Signed WebSocket URL example in Swift. This is intended to be used to sign a WebSocket URL to be used to connect to Amazon Kinesis Video Streams Signaling. It is the same algorithm as in https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-ios but this features modern Swift features.

This PR includes three items:
* **Sigv4 Signer Framework**. The framework contains the logic to sign the secure websocket (WSS) URL using the Sigv4 algorithm.
* **Sigv4 CLI**. This sample application contains a `main()` method demonstrating how to use the **Sigv4 Signer Framework**. To run the sample application, press the run button in the top-left of the XCode UI. The sample command-line application signs your URL then connects to it using the StarScream websocket client.
* **Unit test suite**. You can run the unit tests by long-pressing the run button and switching it to tests.
<img width="249" alt="image" src="https://github.com/aws-samples/amazon-kinesis-video-streams-demos/assets/14988194/c947a315-c112-4c89-815f-35e17fe72ca8">

* All of the newly-written unit tests pass.
<img width="376" alt="image" src="https://github.com/aws-samples/amazon-kinesis-video-streams-demos/assets/14988194/86dfb8fd-0ba7-4d03-aaae-3a5a2392392c">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
