### PR TITLE
Add CI for sigv4 signers in Java and Swift

### DIFF
--- a/.github/workflows/sigv4-java.yaml
+++ b/.github/workflows/sigv4-java.yaml
@@ -1,0 +1,33 @@
+name: SigV4 Java Tests
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - sigv4-signing/java/**
+      - .github/workflows/sigv4-java.yaml
+  pull_request:
+    branches:
+      - master
+    paths:
+      - sigv4-signing/java/**
+      - .github/workflows/sigv4-java.yaml
+
+jobs:
+  run-unit-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java-version: ['8', '11', '17', '21']
+    name: Build and run unit tests (Java ${{ matrix.java-version }})
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up JDK ${{ matrix.java-version }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: corretto
+      - name: Build with Maven
+        run: mvn -B clean verify --file sigv4-signing/java/SigV4Signer.java/pom.xml

--- a/.github/workflows/sigv4-swift.yaml
+++ b/.github/workflows/sigv4-swift.yaml
@@ -1,0 +1,48 @@
+name: SigV4 Swift Tests
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - sigv4-signing/swift/**
+      - .github/workflows/sigv4-swift.yaml
+  pull_request:
+    branches:
+      - master
+    paths:
+      - sigv4-signing/swift/**
+      - .github/workflows/sigv4-swift.yaml
+
+jobs:
+  run-unit-tests:
+    strategy:
+      matrix:
+        config:
+          - mac_ver: '13'
+            xc_ver: '14.3'
+          - mac_ver: '13'
+            xc_ver: '15.0'
+
+    name: 'Build and run unit tests (MacOS ${{ matrix.config.mac_ver }}, XCode ${{ matrix.config.xc_ver }})'
+    runs-on: 'macos-${{ matrix.config.mac_ver }}'
+    steps:
+      - name: Git - Checkout
+        uses: actions/checkout@v4
+      - name: Setup - Xcode
+        run: >-
+          sudo xcode-select -s /Applications/Xcode_${{ matrix.config.xc_ver }}.app
+      - name: Install dependencies
+        run: |
+          cd sigv4-signing/swift/sigv4
+          pod setup
+          pod install --repo-update
+      - name: XCode Test
+        run: set -o pipefail && xcodebuild clean test -workspace sigv4-signing/swift/sigv4/sigv4.xcworkspace -scheme sigv4 -resultBundlePath TestResults -enableCodeCoverage YES | xcpretty
+      - name: Publish results
+        uses: kishikawakatsumi/xcresulttool@v1
+        with:
+          title: 'Test results (MacOS ${{ matrix.config.mac_ver }}, XCode ${{ matrix.config.xc_ver }})'
+          path: TestResults.xcresult
+          upload-bundles: never
+        if: success() || failure()


### PR DESCRIPTION
*Description of changes:*
* Add CI to run the unit tests for the Java and Swift signers and their reference applications.
* Java: Run the tests using Java 8, 11, 17, and 21 for maximum compatibility.
* Swift: Use the latest MacOS and the two recent versions of XCode.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
