### PR TITLE
SDK Canaries to use STS "assume-role" for Authentication

### DIFF
--- a/canary/producer-c/jobs/orchestrator.groovy
+++ b/canary/producer-c/jobs/orchestrator.groovy
@@ -3,7 +3,7 @@ import jenkins.model.*
 WORKSPACE_PRODUCER="canary/producer-c"
 WORKSPACE_CONSUMER="canary/consumer-java"
 GIT_URL='https://github.com/aws-samples/amazon-kinesis-video-streams-demos.git'
-GIT_HASH='sts-auth'
+GIT_HASH='clean-sts-auth'
 RUNNER_JOB_NAME_PREFIX = "producer-runner"
 
 // TODO: Set up configurability to run different parameter combinations

--- a/canary/producer-c/jobs/orchestrator.groovy
+++ b/canary/producer-c/jobs/orchestrator.groovy
@@ -3,7 +3,7 @@ import jenkins.model.*
 WORKSPACE_PRODUCER="canary/producer-c"
 WORKSPACE_CONSUMER="canary/consumer-java"
 GIT_URL='https://github.com/aws-samples/amazon-kinesis-video-streams-demos.git'
-GIT_HASH='master'
+GIT_HASH='sts-auth'
 RUNNER_JOB_NAME_PREFIX = "producer-runner"
 
 // TODO: Set up configurability to run different parameter combinations

--- a/canary/producer-c/jobs/runner.groovy
+++ b/canary/producer-c/jobs/runner.groovy
@@ -224,6 +224,16 @@ pipeline {
             }
         }
 
+        stage('Unset credentials') {
+            steps {
+                script {
+                    env.AWS_ACCESS_KEY_ID = ''
+                    env.AWS_SECRET_ACCESS_KEY = ''
+                    env.AWS_SESSION_TOKEN = ''
+                }
+            }
+        }
+
         // In case of failures, we should add some delays so that we don't get into a tight loop of retrying
         stage('Throttling Retry') {
             when {

--- a/canary/producer-c/jobs/runner.groovy
+++ b/canary/producer-c/jobs/runner.groovy
@@ -177,14 +177,6 @@ pipeline {
         stage('Fetch STS credentials and export to env vars') {
             steps {
                 script {
-                    // Unset the credential env vars in case the EC2 runner had them set somehow.
-                    // We want to use the EC2's role permissions to make the assume-role call.
-                    sh '''
-                            unset AWS_SECRET_ACCESS_KEY
-                            unset AWS_SECRET_KEY
-                            unset AWS_SESSION_TOKEN
-                        '''
-
                     def assumeRoleOutput = sh(script: 'aws sts assume-role --role-arn $AWS_KVS_STS_ROLE_ARN --role-session-name roleSessionName --duration-seconds 43200 --output json',
                                                 returnStdout: true
                                                 ).trim()

--- a/canary/producer-c/jobs/runner.groovy
+++ b/canary/producer-c/jobs/runner.groovy
@@ -6,15 +6,6 @@ HAS_ERROR = false
 
 RUNNING_NODES=0
 
-CREDENTIALS = [
-    [
-        $class: 'AmazonWebServicesCredentialsBinding', 
-        accessKeyVariable: 'AWS_ACCESS_KEY_ID',
-        credentialsId: 'CANARY_CREDENTIALS',
-        secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
-    ]
-]
-
 def buildProducer() {
   sh  """
     cd ./canary/producer-c &&
@@ -40,17 +31,15 @@ def buildConsumer(envs) {
   
 def withRunnerWrapper(envs, fn) {
     withEnv(envs) {
-        withCredentials(CREDENTIALS) {
-            try {
-                fn()
-            } catch (FlowInterruptedException err) {
-                echo 'Aborted due to cancellation'
-                throw err
-            } catch (err) {
-                HAS_ERROR = true
-                // Ignore errors so that we can auto recover by retrying
-                unstable err.toString()
-            }
+        try {
+            fn()
+        } catch (FlowInterruptedException err) {
+            echo 'Aborted due to cancellation'
+            throw err
+        } catch (err) {
+            HAS_ERROR = true
+            // Ignore errors so that we can auto recover by retrying
+            unstable err.toString()
         }
     }
 }
@@ -134,7 +123,7 @@ def runClient(isProducer, params) {
         withRunnerWrapper(envs) {
             sh '''
                 cd $WORKSPACE/canary/consumer-java
-                java -classpath target/aws-kinesisvideo-producer-sdk-canary-consumer-1.0-SNAPSHOT.jar:$(cat tmp_jar) -Daws.accessKeyId=${AWS_ACCESS_KEY_ID} -Daws.secretKey=${AWS_SECRET_ACCESS_KEY} com.amazon.kinesis.video.canary.consumer.ProducerSdkCanaryConsumer
+                java -classpath target/aws-kinesisvideo-producer-sdk-canary-consumer-1.0-SNAPSHOT.jar:$(cat tmp_jar) -Daws.accessKeyId=${AWS_ACCESS_KEY_ID} -Daws.secretKey=${AWS_SECRET_ACCESS_KEY} -Daws.sessionToken=${AWS_SESSION_TOKEN} com.amazon.kinesis.video.canary.consumer.ProducerSdkCanaryConsumer
             '''
         }
     }
@@ -173,12 +162,33 @@ pipeline {
         booleanParam(name: 'USE_IOT')
     }
 
+    // Set the role ARN to environment to avoid string interpolation to follow Jenkins security guidelines.
+    environment {
+        AWS_KVS_STS_ROLE_ARN = credentials('CANARY_STS_ROLE_ARN')
+    }
+
     stages {
         stage('Echo params') {
             steps {
                 echo params.toString()
             }
         }
+        
+        stage('Fetch STS credentials and export to env vars') {
+            steps {
+                script {
+                    def assumeRoleOutput = sh(script: 'aws sts assume-role --role-arn $AWS_KVS_STS_ROLE_ARN --role-session-name roleSessionName --duration-seconds 43200 --output json',
+                                                returnStdout: true
+                                                ).trim()
+                    def assumeRoleJson = readJSON text: assumeRoleOutput
+
+                    env.AWS_ACCESS_KEY_ID = assumeRoleJson.Credentials.AccessKeyId
+                    env.AWS_SECRET_ACCESS_KEY = assumeRoleJson.Credentials.SecretAccessKey
+                    env.AWS_SESSION_TOKEN = assumeRoleJson.Credentials.SessionToken
+                }
+            }
+        }
+
         stage('Set build description') {
             steps {
                 script {

--- a/canary/producer-c/jobs/runner.groovy
+++ b/canary/producer-c/jobs/runner.groovy
@@ -177,6 +177,14 @@ pipeline {
         stage('Fetch STS credentials and export to env vars') {
             steps {
                 script {
+                    // Unset the credential env vars in case the EC2 runner had them set somehow.
+                    // We want to use the EC2's role permissions to make the assume-role call.
+                    sh '''
+                            unset AWS_SECRET_ACCESS_KEY
+                            unset AWS_SECRET_KEY
+                            unset AWS_SESSION_TOKEN
+                        '''
+
                     def assumeRoleOutput = sh(script: 'aws sts assume-role --role-arn $AWS_KVS_STS_ROLE_ARN --role-session-name roleSessionName --duration-seconds 43200 --output json',
                                                 returnStdout: true
                                                 ).trim()

--- a/canary/producer-cpp/jobs/orchestrator.groovy
+++ b/canary/producer-cpp/jobs/orchestrator.groovy
@@ -1,7 +1,7 @@
 import jenkins.model.*
 
 GIT_URL='https://github.com/aws-samples/amazon-kinesis-video-streams-demos.git'
-GIT_HASH='master'
+GIT_HASH='sts-auth'
 RUNNER_JOB_NAME_PREFIX = "producercpp-runner"
 
 LONG_RUN_DURATION_IN_SECONDS = 12 * 60 * 60

--- a/canary/producer-cpp/jobs/orchestrator.groovy
+++ b/canary/producer-cpp/jobs/orchestrator.groovy
@@ -1,7 +1,7 @@
 import jenkins.model.*
 
 GIT_URL='https://github.com/aws-samples/amazon-kinesis-video-streams-demos.git'
-GIT_HASH='sts-auth'
+GIT_HASH='clean-sts-auth'
 RUNNER_JOB_NAME_PREFIX = "producercpp-runner"
 
 LONG_RUN_DURATION_IN_SECONDS = 12 * 60 * 60

--- a/canary/producer-cpp/jobs/runner.groovy
+++ b/canary/producer-cpp/jobs/runner.groovy
@@ -179,6 +179,16 @@ pipeline {
             }
         }
 
+        stage('Unset credentials') {
+            steps {
+                script {
+                    env.AWS_ACCESS_KEY_ID = ''
+                    env.AWS_SECRET_ACCESS_KEY = ''
+                    env.AWS_SESSION_TOKEN = ''
+                }
+            }
+        }
+
         // In case of failures, we should add some delays so that we don't get into a tight loop of retrying
         stage('Throttling Retry') {
             when {

--- a/canary/producer-cpp/jobs/runner.groovy
+++ b/canary/producer-cpp/jobs/runner.groovy
@@ -6,15 +6,6 @@ HAS_ERROR = false
 
 RUNNING_NODES=0
 
-CREDENTIALS = [
-    [
-        $class: 'AmazonWebServicesCredentialsBinding', 
-        accessKeyVariable: 'AWS_ACCESS_KEY_ID',
-        credentialsId: 'CANARY_CREDENTIALS',
-        secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
-    ]
-]
-
 def buildProducer() {
   sh  """
     cd ./canary/producer-cpp/scripts &&
@@ -30,17 +21,15 @@ def buildProducer() {
   
 def withRunnerWrapper(envs, fn) {
     withEnv(envs) {
-        withCredentials(CREDENTIALS) {
-            try {
-                fn()
-            } catch (FlowInterruptedException err) {
-                echo 'Aborted due to cancellation'
-                throw err
-            } catch (err) {
-                HAS_ERROR = true
-                // Ignore errors so that we can auto recover by retrying
-                unstable err.toString()
-            }
+        try {
+            fn()
+        } catch (FlowInterruptedException err) {
+            echo 'Aborted due to cancellation'
+            throw err
+        } catch (err) {
+            HAS_ERROR = true
+            // Ignore errors so that we can auto recover by retrying
+            unstable err.toString()
         }
     }
 }
@@ -143,7 +132,27 @@ pipeline {
         booleanParam(name: 'USE_IOT')
     }
 
+    // Set the role ARN to environment to avoid string interpolation to follow Jenkins security guidelines.
+    environment {
+        AWS_KVS_STS_ROLE_ARN = credentials('CANARY_STS_ROLE_ARN')
+    }
+
     stages {
+        stage('Fetch STS credentials and export to env vars') {
+            steps {
+                script {
+                    def assumeRoleOutput = sh(script: 'aws sts assume-role --role-arn $AWS_KVS_STS_ROLE_ARN --role-session-name roleSessionName --duration-seconds 43200 --output json',
+                                                returnStdout: true
+                                                ).trim()
+                    def assumeRoleJson = readJSON text: assumeRoleOutput
+
+                    env.AWS_ACCESS_KEY_ID = assumeRoleJson.Credentials.AccessKeyId
+                    env.AWS_SECRET_ACCESS_KEY = assumeRoleJson.Credentials.SecretAccessKey
+                    env.AWS_SESSION_TOKEN = assumeRoleJson.Credentials.SessionToken
+                }
+            }
+        }
+        
         stage('Echo params') {
             steps {
                 echo params.toString()

--- a/canary/webrtc-c/jobs/orchestrator.groovy
+++ b/canary/webrtc-c/jobs/orchestrator.groovy
@@ -13,7 +13,7 @@ STORAGE_EXTENDED_DURATION_IN_SECONDS = 43200 // 12 hr
 MIN_RETRY_DELAY_IN_SECONDS = 60
 COLD_STARTUP_DELAY_IN_SECONDS = 60 * 60
 GIT_URL = 'https://github.com/aws-samples/amazon-kinesis-video-streams-demos.git'
-GIT_HASH = 'master'
+GIT_HASH = 'sts-auth'
 COMMON_PARAMS = [
     string(name: 'AWS_KVS_LOG_LEVEL', value: "2"),
     string(name: 'DEBUG_LOG_SDP', value: "TRUE"),

--- a/canary/webrtc-c/jobs/orchestrator.groovy
+++ b/canary/webrtc-c/jobs/orchestrator.groovy
@@ -13,7 +13,7 @@ STORAGE_EXTENDED_DURATION_IN_SECONDS = 43200 // 12 hr
 MIN_RETRY_DELAY_IN_SECONDS = 60
 COLD_STARTUP_DELAY_IN_SECONDS = 60 * 60
 GIT_URL = 'https://github.com/aws-samples/amazon-kinesis-video-streams-demos.git'
-GIT_HASH = 'sts-auth'
+GIT_HASH = 'clean-sts-auth'
 COMMON_PARAMS = [
     string(name: 'AWS_KVS_LOG_LEVEL', value: "2"),
     string(name: 'DEBUG_LOG_SDP', value: "TRUE"),

--- a/canary/webrtc-c/jobs/runner.groovy
+++ b/canary/webrtc-c/jobs/runner.groovy
@@ -108,10 +108,7 @@ def buildPeer(isMaster, params) {
       'AWS_IOT_CORE_CERT': "${core_cert_file}",
       'AWS_IOT_CORE_PRIVATE_KEY': "${private_key_file}",
       'AWS_IOT_CORE_ROLE_ALIAS': "${role_alias}",
-      'AWS_IOT_CORE_THING_NAME': "${thing_name}",
-      'AWS_ACCESS_KEY_ID': env.AWS_ACCESS_KEY_ID,
-      'AWS_SECRET_ACCESS_KEY': env.AWS_SECRET_ACCESS_KEY,
-      'AWS_SESSION_TOKEN': env.AWS_SESSION_TOKEN
+      'AWS_IOT_CORE_THING_NAME': "${thing_name}"
     ].collect{ k, v -> "${k}=${v}" }
 
     withRunnerWrapper(envs) {
@@ -155,10 +152,7 @@ def buildSignaling(params) {
       'AWS_IOT_CORE_CERT': "${core_cert_file}",
       'AWS_IOT_CORE_PRIVATE_KEY': "${private_key_file}",
       'AWS_IOT_CORE_ROLE_ALIAS': "${role_alias}",
-      'AWS_IOT_CORE_THING_NAME': "${thing_name}",
-      'AWS_ACCESS_KEY_ID': env.AWS_ACCESS_KEY_ID,
-      'AWS_SECRET_ACCESS_KEY': env.AWS_SECRET_ACCESS_KEY,
-      'AWS_SESSION_TOKEN': env.AWS_SESSION_TOKEN
+      'AWS_IOT_CORE_THING_NAME': "${thing_name}"
     ].collect({ k, v -> "${k}=${v}" })
 
     withRunnerWrapper(envs) {
@@ -187,10 +181,7 @@ def buildStorageCanary(isConsumer, params) {
       'AWS_IOT_CORE_CERT': "${core_cert_file}",
       'AWS_IOT_CORE_PRIVATE_KEY': "${private_key_file}",
       'AWS_IOT_CORE_ROLE_ALIAS': "${role_alias}",
-      'AWS_IOT_CORE_THING_NAME': "${thing_name}",
-      'AWS_ACCESS_KEY_ID': env.AWS_ACCESS_KEY_ID,
-      'AWS_SECRET_ACCESS_KEY': env.AWS_SECRET_ACCESS_KEY,
-      'AWS_SESSION_TOKEN': env.AWS_SESSION_TOKEN
+      'AWS_IOT_CORE_THING_NAME': "${thing_name}"
     ]
 
     def masterEnvs = [

--- a/canary/webrtc-c/jobs/runner.groovy
+++ b/canary/webrtc-c/jobs/runner.groovy
@@ -3,14 +3,6 @@ import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
 START_TIMESTAMP = new Date().getTime()
 RUNNING_NODES_IN_BUILDING = 0
 HAS_ERROR = false
-CREDENTIALS = [
-    [
-        $class: 'AmazonWebServicesCredentialsBinding', 
-        accessKeyVariable: 'AWS_ACCESS_KEY_ID',
-        credentialsId: 'CANARY_CREDENTIALS',
-        secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
-    ]
-]
 
 def buildWebRTCProject(useMbedTLS, thing_prefix) {
     echo 'Flag set to ' + useMbedTLS
@@ -58,17 +50,15 @@ def buildConsumerProject() {
 
 def withRunnerWrapper(envs, fn) {
     withEnv(envs) {
-        withCredentials(CREDENTIALS) {
-            try {
-                fn()
-            } catch (FlowInterruptedException err) {
-                echo 'Aborted due to cancellation'
-                throw err
-            } catch (err) {
-                HAS_ERROR = true
-                // Ignore errors so that we can auto recover by retrying
-                unstable err.toString()
-            }
+        try {
+            fn()
+        } catch (FlowInterruptedException err) {
+            echo 'Aborted due to cancellation'
+            throw err
+        } catch (err) {
+            HAS_ERROR = true
+            // Ignore errors so that we can auto recover by retrying
+            unstable err.toString()
         }
     }
 }
@@ -238,7 +228,7 @@ def buildStorageCanary(isConsumer, params) {
         withRunnerWrapper(envs) {
             sh '''
                 cd $WORKSPACE/canary/consumer-java
-                java -classpath target/aws-kinesisvideo-producer-sdk-canary-consumer-1.0-SNAPSHOT.jar:$(cat tmp_jar) -Daws.accessKeyId=${AWS_ACCESS_KEY_ID} -Daws.secretKey=${AWS_SECRET_ACCESS_KEY} com.amazon.kinesis.video.canary.consumer.WebrtcStorageCanaryConsumer
+                java -classpath target/aws-kinesisvideo-producer-sdk-canary-consumer-1.0-SNAPSHOT.jar:$(cat tmp_jar) -Daws.accessKeyId=${AWS_ACCESS_KEY_ID} -Daws.secretKey=${AWS_SECRET_ACCESS_KEY} -Daws.sessionToken=${AWS_SESSION_TOKEN} com.amazon.kinesis.video.canary.consumer.WebrtcStorageCanaryConsumer
             '''
         }
     }
@@ -272,8 +262,28 @@ pipeline {
         string(name: 'GIT_HASH')
         booleanParam(name: 'FIRST_ITERATION', defaultValue: true)
     }
+    
+    // Set the role ARN to environment to avoid string interpolation to follow Jenkins security guidelines.
+    environment {
+        AWS_KVS_STS_ROLE_ARN = credentials('CANARY_STS_ROLE_ARN')
+    }
 
     stages {
+        stage('Fetch STS credentials and export to env vars') {
+            steps {
+                script {
+                    def assumeRoleOutput = sh(script: 'aws sts assume-role --role-arn $AWS_KVS_STS_ROLE_ARN --role-session-name roleSessionName --duration-seconds 43200 --output json',
+                                                returnStdout: true
+                                                ).trim()
+                    def assumeRoleJson = readJSON text: assumeRoleOutput
+
+                    env.AWS_ACCESS_KEY_ID = assumeRoleJson.Credentials.AccessKeyId
+                    env.AWS_SECRET_ACCESS_KEY = assumeRoleJson.Credentials.SecretAccessKey
+                    env.AWS_SESSION_TOKEN = assumeRoleJson.Credentials.SessionToken
+                }
+            }
+        }
+
         stage('Set build description') {
             steps {
                 script {
@@ -282,6 +292,7 @@ pipeline {
                 }
             }
         }
+
         stage('Preparation') {
             steps {
               echo params.toString()

--- a/canary/webrtc-c/jobs/runner.groovy
+++ b/canary/webrtc-c/jobs/runner.groovy
@@ -108,7 +108,10 @@ def buildPeer(isMaster, params) {
       'AWS_IOT_CORE_CERT': "${core_cert_file}",
       'AWS_IOT_CORE_PRIVATE_KEY': "${private_key_file}",
       'AWS_IOT_CORE_ROLE_ALIAS': "${role_alias}",
-      'AWS_IOT_CORE_THING_NAME': "${thing_name}"
+      'AWS_IOT_CORE_THING_NAME': "${thing_name}",
+      'AWS_ACCESS_KEY_ID': env.AWS_ACCESS_KEY_ID,
+      'AWS_SECRET_ACCESS_KEY': env.AWS_SECRET_ACCESS_KEY,
+      'AWS_SESSION_TOKEN': env.AWS_SESSION_TOKEN
     ].collect{ k, v -> "${k}=${v}" }
 
     withRunnerWrapper(envs) {
@@ -152,7 +155,10 @@ def buildSignaling(params) {
       'AWS_IOT_CORE_CERT': "${core_cert_file}",
       'AWS_IOT_CORE_PRIVATE_KEY': "${private_key_file}",
       'AWS_IOT_CORE_ROLE_ALIAS': "${role_alias}",
-      'AWS_IOT_CORE_THING_NAME': "${thing_name}"
+      'AWS_IOT_CORE_THING_NAME': "${thing_name}",
+      'AWS_ACCESS_KEY_ID': env.AWS_ACCESS_KEY_ID,
+      'AWS_SECRET_ACCESS_KEY': env.AWS_SECRET_ACCESS_KEY,
+      'AWS_SESSION_TOKEN': env.AWS_SESSION_TOKEN
     ].collect({ k, v -> "${k}=${v}" })
 
     withRunnerWrapper(envs) {
@@ -181,7 +187,10 @@ def buildStorageCanary(isConsumer, params) {
       'AWS_IOT_CORE_CERT': "${core_cert_file}",
       'AWS_IOT_CORE_PRIVATE_KEY': "${private_key_file}",
       'AWS_IOT_CORE_ROLE_ALIAS': "${role_alias}",
-      'AWS_IOT_CORE_THING_NAME': "${thing_name}"
+      'AWS_IOT_CORE_THING_NAME': "${thing_name}",
+      'AWS_ACCESS_KEY_ID': env.AWS_ACCESS_KEY_ID,
+      'AWS_SECRET_ACCESS_KEY': env.AWS_SECRET_ACCESS_KEY,
+      'AWS_SESSION_TOKEN': env.AWS_SESSION_TOKEN
     ]
 
     def masterEnvs = [

--- a/canary/webrtc-c/jobs/runner.groovy
+++ b/canary/webrtc-c/jobs/runner.groovy
@@ -414,6 +414,16 @@ pipeline {
             }
         }
 
+        stage('Unset credentials') {
+            steps {
+                script {
+                    env.AWS_ACCESS_KEY_ID = ''
+                    env.AWS_SECRET_ACCESS_KEY = ''
+                    env.AWS_SESSION_TOKEN = ''
+                }
+            }
+        }
+
         // In case of failures, we should add some delays so that we don't get into a tight loop of retrying
         stage('Throttling Retry') {
             when {

--- a/canary/webrtc-c/src/CanarySignaling.cpp
+++ b/canary/webrtc-c/src/CanarySignaling.cpp
@@ -316,7 +316,6 @@ STATUS run(Canary::PConfig pConfig)
         } else {
             CHK_STATUS(createStaticCredentialProvider((PCHAR) pConfig->accessKey.value.c_str(), 0, (PCHAR) pConfig->secretKey.value.c_str(), 0,
                                                       (PCHAR) pConfig->sessionToken.value.c_str(), 0, MAX_UINT64, &pCredentialProvider));
-
         }
     }
 


### PR DESCRIPTION
Transition the SDK Canaries to use STS "assume-role" calls for fetching short-term credentials.

The authentication is conducted in the Jenkins pipeline, so there are no app changes required.

These changes were tested on the Canary server for WebRTC, Producer C, Producer Cpp, and Consumer jobs.