### PR TITLE
Handle linked resources for the webrtc ingestion feature

### DIFF
--- a/python/cleanup/kvs_cleanup.py
+++ b/python/cleanup/kvs_cleanup.py
@@ -11,6 +11,11 @@ import botocore
 MAX_REQUESTS_PER_SEC = 20
 SLEEP_DURATION_MS = 1 / MAX_REQUESTS_PER_SEC
 
+# This API has a lower limit than the rest. Want to avoid slowing down the entire script
+# just for this though
+MAX_REQUESTS_UPDATE_MEDIA_STORAGE_CONFIGURATION = 5
+SLEEP_DURATION_MS_UPDATE_MEDIA_STORAGE_CONFIGURATION = 1 / MAX_REQUESTS_UPDATE_MEDIA_STORAGE_CONFIGURATION
+
 # Create a Kinesis Video client
 client = boto3.client('kinesisvideo')
 
@@ -65,6 +70,12 @@ def delete_old_test_streams(stream_regex: str, dry_run: bool, time_threshold):
                             if e.response['Error']['Code'] == 'ClientLimitExceededException':
                                 # Try again when rate limited
                                 sleep(SLEEP_DURATION_MS * (attempt + 1))
+                                continue
+                            elif (e.response['Error']['Code'] == 'ResourceInUseException' and
+                                  'Disable MediaStorageConfiguration to delete the stream' in e.response['Error'][
+                                      'Message']):
+                                unlink_resources(stream_arn=stream_arn)
+                                sleep(SLEEP_DURATION_MS_UPDATE_MEDIA_STORAGE_CONFIGURATION * (attempt + 1))
                                 continue
                             raise e
 
@@ -131,6 +142,12 @@ def delete_old_test_channels(channel_regex: str, dry_run: bool, time_threshold):
                                 # Try again when rate limited
                                 sleep(SLEEP_DURATION_MS * (attempt + 1))
                                 continue
+                            elif (e.response['Error']['Code'] == 'ResourceInUseException' and
+                                  'Disable MediaStorageConfiguration to delete the channel' in e.response['Error'][
+                                      'Message']):
+                                unlink_resources(channel_arn=channel_arn)
+                                sleep(SLEEP_DURATION_MS_UPDATE_MEDIA_STORAGE_CONFIGURATION * (attempt + 1))
+                                continue
                             raise e
 
                     sleep(SLEEP_DURATION_MS)
@@ -143,6 +160,18 @@ def delete_old_test_channels(channel_regex: str, dry_run: bool, time_threshold):
             break
 
     return channel_count, channels_deleted
+
+
+def unlink_resources(stream_arn: str = None, channel_arn: str = None):
+    if not stream_arn and not channel_arn:
+        raise SyntaxError('Please provide either a stream arn or channel arn')
+
+    if not channel_arn:
+        response = client.describe_mapped_resource_configuration(StreamARN=stream_arn)
+        channel_arn = response.get('MappedResourceConfigurationList')[0].get('ARN')
+
+    print(f'Unlinking: {stream_arn=}, {channel_arn=}')
+    client.update_media_storage_configuration(ChannelARN=channel_arn, MediaStorageConfiguration={'Status': 'DISABLED'})
 
 
 def main():


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*Description of changes:*
- Handle the case for linked resources. Currently, if the resources are linked, the following error occurs.

```
An error occurred (ResourceInUseException) when calling the DeleteStream operation: Disable MediaStorageConfiguration to delete the stream
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.ResourceInUseException: An error occurred (ResourceInUseException) when calling the DeleteStream operation: Disable MediaStorageConfiguration to delete the stream
```
- The script will call delete, and if the error occurs, will first unlink and then try deleting again. The alternative (not implemented) would be to call describe_mapped_resource_configuration/describe_media_storage_configuration for every single resource before calling delete, which is not efficient since it will double the API calls. Considering the majority use case is not having resources linked/configured for ingestion, this seems like a great trade-off.
- The script is open-source and easy to change, so anyone can change it however they want.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
