### PR TITLE
Add StorageLowFps canary test and fix outbound RTP metrics

### DIFF
--- a/canary/consumer-java/src/main/java/com/amazon/kinesis/video/canary/consumer/CanaryConstants.java
+++ b/canary/consumer-java/src/main/java/com/amazon/kinesis/video/canary/consumer/CanaryConstants.java
@@ -28,6 +28,10 @@ public final class CanaryConstants {
     public static final String GAMMA_SUB_RECONNECT_LABEL = "GammaStorageSubReconnect";
     public static final String GAMMA_SINGLE_RECONNECT_LABEL = "GammaStorageSingleReconnect";
 
+    // Low FPS variants
+    public static final String LOW_FPS_LABEL = "StorageLowFps";
+    public static final String GAMMA_LOW_FPS_LABEL = "GammaStorageLowFps";
+
     public static final String CW_DIMENSION_INDIVIDUAL = "StorageWebRTCSDKCanaryStreamName";
     public static final String CW_DIMENSION_AGGREGATE = "StorageWebRTCSDKCanaryLabel";
 

--- a/canary/consumer-java/src/main/java/com/amazon/kinesis/video/canary/consumer/WebrtcStorageCanaryConsumer.java
+++ b/canary/consumer-java/src/main/java/com/amazon/kinesis/video/canary/consumer/WebrtcStorageCanaryConsumer.java
@@ -282,7 +282,9 @@ public class WebrtcStorageCanaryConsumer {
 
         switch (mCanaryLabel) {
             case CanaryConstants.PERIODIC_LABEL:
-            case CanaryConstants.GAMMA_PERIODIC_LABEL: {
+            case CanaryConstants.GAMMA_PERIODIC_LABEL:
+            case CanaryConstants.LOW_FPS_LABEL:
+            case CanaryConstants.GAMMA_LOW_FPS_LABEL: {
                 logger.info("Periodic case: canaryRunTime=" + canaryRunTime
                         + "s, mCanaryStartTime=" + mCanaryStartTime
                         + ", now=" + new Date()

--- a/canary/webrtc-c/jobs/gamma_orchestrator.groovy
+++ b/canary/webrtc-c/jobs/gamma_orchestrator.groovy
@@ -18,7 +18,7 @@
  */
 
 GIT_URL = 'https://github.com/aws-samples/amazon-kinesis-video-streams-demos.git'
-GIT_HASH = 'low-fps-test'
+GIT_HASH = 'metric-implementation'
 
 // Dedicated gamma runner job name
 GAMMA_RUNNER_JOB = "webrtc-gamma-runner"

--- a/canary/webrtc-c/jobs/gamma_orchestrator.groovy
+++ b/canary/webrtc-c/jobs/gamma_orchestrator.groovy
@@ -8,6 +8,7 @@
  *   - StorageWithViewer (1 viewer)
  *   - StorageTwoViewers (2 viewers)  
  *   - StorageThreeViewers (3 viewers)
+ *   - StorageLowFps (10 fps)
  * 
  * Usage:
  *   1. Click "Build with Parameters"
@@ -17,7 +18,7 @@
  */
 
 GIT_URL = 'https://github.com/aws-samples/amazon-kinesis-video-streams-demos.git'
-GIT_HASH = 'metric-implementation'
+GIT_HASH = 'low-fps-test'
 
 // Dedicated gamma runner job name
 GAMMA_RUNNER_JOB = "webrtc-gamma-runner"
@@ -81,6 +82,11 @@ pipeline {
             defaultValue: true,
             description: 'Run StorageSingleReconnect test (master + consumer, 65 min)'
         )
+        booleanParam(
+            name: 'RUN_STORAGE_LOW_FPS',
+            defaultValue: true,
+            description: 'Run StorageLowFps test (master + consumer at 10 fps, 156s)'
+        )
         string(
             name: 'GIT_HASH',
             defaultValue: GIT_HASH,
@@ -113,7 +119,7 @@ pipeline {
             steps {
                 script {
                     
-                    if (!params.RUN_STORAGE_WITH_VIEWER && !params.RUN_STORAGE_TWO_VIEWERS && !params.RUN_STORAGE_THREE_VIEWERS && !params.RUN_STORAGE_PERIODIC && !params.RUN_STORAGE_SUB_RECONNECT && !params.RUN_STORAGE_SINGLE_RECONNECT) {
+                    if (!params.RUN_STORAGE_WITH_VIEWER && !params.RUN_STORAGE_TWO_VIEWERS && !params.RUN_STORAGE_THREE_VIEWERS && !params.RUN_STORAGE_PERIODIC && !params.RUN_STORAGE_SUB_RECONNECT && !params.RUN_STORAGE_SINGLE_RECONNECT && !params.RUN_STORAGE_LOW_FPS) {
                         error "At least one test must be selected to run."
                     }
                     
@@ -128,6 +134,7 @@ pipeline {
                     if (params.RUN_STORAGE_PERIODIC) echo "  - StoragePeriodic (master + consumer, 156s)"
                     if (params.RUN_STORAGE_SUB_RECONNECT) echo "  - StorageSubReconnect (master + consumer, 45 min)"
                     if (params.RUN_STORAGE_SINGLE_RECONNECT) echo "  - StorageSingleReconnect (master + consumer, 65 min)"
+                    if (params.RUN_STORAGE_LOW_FPS) echo "  - StorageLowFps (master + consumer at 10 fps, 156s)"
                     if (params.RUN_STORAGE_WITH_VIEWER) echo "  - StorageWithViewer (1 viewer)"
                     if (params.RUN_STORAGE_TWO_VIEWERS) echo "  - StorageTwoViewers (2 viewers)"
                     if (params.RUN_STORAGE_THREE_VIEWERS) echo "  - StorageThreeViewers (3 viewers)"
@@ -390,6 +397,46 @@ pipeline {
                                 propagate: false
                             )
                             echo "StorageSingleReconnect result: ${result.result}"
+                        }
+                    }
+                }
+
+                stage('StorageLowFps') {
+                    when {
+                        expression { return params.RUN_STORAGE_LOW_FPS }
+                    }
+                    steps {
+                        script {
+                            echo "Starting StorageLowFps test (10 fps)..."
+                            def result = build(
+                                job: GAMMA_RUNNER_JOB,
+                                parameters: [
+                                    string(name: 'AWS_KVS_LOG_LEVEL', value: "2"),
+                                    string(name: 'GIT_URL', value: GIT_URL),
+                                    string(name: 'GIT_HASH', value: env.CURRENT_GIT_HASH),
+                                    string(name: 'LOG_GROUP_NAME', value: "WebrtcSDK"),
+                                    booleanParam(name: 'IS_STORAGE', value: true),
+                                    booleanParam(name: 'VIDEO_VERIFY_ENABLED', value: true),
+                                    string(name: 'DURATION_IN_SECONDS', value: "156"),
+                                    string(name: 'MASTER_NODE_LABEL', value: "gamma-webrtc-storage-master"),
+                                    string(name: 'CONSUMER_NODE_LABEL', value: "gamma-webrtc-storage-consumer"),
+                                    string(name: 'RUNNER_LABEL', value: "GammaStorageLowFps"),
+                                    string(name: 'SCENARIO_LABEL', value: "GammaStorageLowFps"),
+                                    string(name: 'AWS_DEFAULT_REGION', value: params.AWS_DEFAULT_REGION),
+                                    string(name: 'ENDPOINT', value: params.ENDPOINT),
+                                    string(name: 'METRIC_SUFFIX', value: "-gamma"),
+                                    booleanParam(name: 'USE_TURN', value: true),
+                                    booleanParam(name: 'TRICKLE_ICE', value: true),
+                                    booleanParam(name: 'FIRST_ITERATION', value: true),
+                                    booleanParam(name: 'RESCHEDULE', value: params.RESCHEDULE),
+                                    booleanParam(name: 'NO_LOOP_FRAMES', value: true),
+                                    string(name: 'STORAGE_FPS', value: "10"),
+                                    string(name: 'JS_BRANCH', value: params.JS_BRANCH),
+                                ],
+                                wait: true,
+                                propagate: false
+                            )
+                            echo "StorageLowFps result: ${result.result}"
                         }
                     }
                 }

--- a/canary/webrtc-c/jobs/gamma_runner.groovy
+++ b/canary/webrtc-c/jobs/gamma_runner.groovy
@@ -285,7 +285,8 @@ def buildStorageCanary(isConsumer, params) {
         'CANARY_CHANNEL_NAME': "${env.JOB_NAME}-${params.RUNNER_LABEL}",
         'AWS_DEFAULT_REGION': params.AWS_DEFAULT_REGION,
         'CONTROL_PLANE_URI': params.ENDPOINT ?: '',
-        'CANARY_NO_LOOP_FRAMES': params.NO_LOOP_FRAMES ?: false
+        'CANARY_NO_LOOP_FRAMES': params.NO_LOOP_FRAMES ?: false,
+        'CANARY_FRAME_RATE': params.STORAGE_FPS ?: ''
     ]
 
     def repoDir = "${env.HOME}/webrtc-c-storage-master/repo"
@@ -443,6 +444,7 @@ pipeline {
         booleanParam(name: 'TRICKLE_ICE', defaultValue: false)
         booleanParam(name: 'FORCE_TURN', defaultValue: false)
         booleanParam(name: 'NO_LOOP_FRAMES', defaultValue: false, description: 'Stop after sending all frames once instead of looping')
+        string(name: 'STORAGE_FPS', defaultValue: '', description: 'Override storage master frame rate (e.g., 10 for low FPS test). Empty uses default 30 fps.')
         string(name: 'JS_BRANCH', defaultValue: 'master', description: 'JS SDK branch name to clone and serve locally (default: master)')
     }
     
@@ -732,6 +734,7 @@ pipeline {
                         booleanParam(name: 'TRICKLE_ICE', value: params.TRICKLE_ICE),
                         booleanParam(name: 'FORCE_TURN', value: params.FORCE_TURN),
                         booleanParam(name: 'NO_LOOP_FRAMES', value: params.NO_LOOP_FRAMES),
+                        string(name: 'STORAGE_FPS', value: params.STORAGE_FPS),
                         string(name: 'JS_BRANCH', value: params.JS_BRANCH),
                     ]
 

--- a/canary/webrtc-c/jobs/orchestrator.groovy
+++ b/canary/webrtc-c/jobs/orchestrator.groovy
@@ -343,6 +343,29 @@ pipeline {
                             wait: false
                         )
 
+                        // Storage Low FPS — streams at 10 fps instead of default 30 fps.
+                        build(
+                            job: NEXT_AVAILABLE_RUNNER,
+                            parameters: COMMON_PARAMS + [
+                                booleanParam(name: 'IS_SIGNALING', value: false),
+                                booleanParam(name: 'IS_STORAGE', value: true),
+                                booleanParam(name: 'IS_STORAGE_SINGLE_NODE', value: true),
+                                booleanParam(name: 'USE_TURN', value: true),
+                                booleanParam(name: 'TRICKLE_ICE', value: true),
+                                booleanParam(name: 'USE_IOT', value: false),
+                                booleanParam(name: 'VIDEO_VERIFY_ENABLED', value: true),
+                                string(name: 'DURATION_IN_SECONDS', value: STORAGE_PERIODIC_DURATION_IN_SECONDS.toString()),
+                                string(name: 'MASTER_NODE_LABEL', value: "webrtc-storage-master"),
+                                string(name: 'CONSUMER_NODE_LABEL', value: "webrtc-storage-consumer"),
+                                string(name: 'RUNNER_LABEL', value: "StorageLowFps"),
+                                string(name: 'SCENARIO_LABEL', value: "StorageLowFps"),
+                                string(name: 'AWS_DEFAULT_REGION', value: "us-west-2"),
+                                booleanParam(name: 'NO_LOOP_FRAMES', value: true),
+                                string(name: 'STORAGE_FPS', value: "10"),
+                            ],
+                            wait: false
+                        )
+
                         // Storage Sub-Reconnect.
                         build(
                             job: NEXT_AVAILABLE_RUNNER,

--- a/canary/webrtc-c/jobs/runner.groovy
+++ b/canary/webrtc-c/jobs/runner.groovy
@@ -396,7 +396,8 @@ def buildStorageCanary(isConsumer, params) {
       'CANARY_CHANNEL_NAME': "${env.JOB_NAME}-${params.RUNNER_LABEL}",
       'AWS_DEFAULT_REGION': params.AWS_DEFAULT_REGION,
       'CONTROL_PLANE_URI': params.ENDPOINT ?: '',
-      'CANARY_NO_LOOP_FRAMES': params.NO_LOOP_FRAMES ?: false
+      'CANARY_NO_LOOP_FRAMES': params.NO_LOOP_FRAMES ?: false,
+      'CANARY_FRAME_RATE': params.STORAGE_FPS ?: ''
     ]
 
     def repoDir = "${env.HOME}/webrtc-c-storage-master/repo"
@@ -566,6 +567,7 @@ pipeline {
         string(name: 'VIEWER_SESSION_DURATION_SECONDS', defaultValue: '900', description: 'Hard timeout in seconds for the viewer process (default 15 minutes, must be larger than monitoring duration)')
         booleanParam(name: 'VIDEO_VERIFY_ENABLED', defaultValue: false, description: 'Enable consumer-side video verification via GetClip')
         booleanParam(name: 'NO_LOOP_FRAMES', defaultValue: false, description: 'Stop after sending all frames once instead of looping')
+        string(name: 'STORAGE_FPS', defaultValue: '', description: 'Override storage master frame rate (e.g., 10 for low FPS test). Empty uses default 30 fps.')
     }
     
     // Set the role ARN to environment to avoid string interpolation to follow Jenkins security guidelines.
@@ -944,6 +946,7 @@ pipeline {
                       string(name: 'VIEWER_SESSION_DURATION_SECONDS', value: params.VIEWER_SESSION_DURATION_SECONDS),
                       booleanParam(name: 'VIDEO_VERIFY_ENABLED', value: params.VIDEO_VERIFY_ENABLED),
                       booleanParam(name: 'NO_LOOP_FRAMES', value: params.NO_LOOP_FRAMES),
+                      string(name: 'STORAGE_FPS', value: params.STORAGE_FPS),
                       booleanParam(name: 'FIRST_ITERATION', value: false)
                     ]
 

--- a/canary/webrtc-c/src/Peer.h
+++ b/canary/webrtc-c/src/Peer.h
@@ -15,6 +15,7 @@ typedef struct {
     UINT64 prevFramesSent;
     UINT64 prevNackCount;
     UINT64 prevRetxBytesSent;
+    UINT64 prevPliCount;
     std::atomic<UINT64> videoFramesGenerated;
     UINT64 videoBytesGenerated;
     DOUBLE framesPercentageDiscarded;

--- a/canary/webrtc-c/src/media-server-storage/kvsWebRTCClientMaster.cpp
+++ b/canary/webrtc-c/src/media-server-storage/kvsWebRTCClientMaster.cpp
@@ -221,10 +221,28 @@ PVOID sendVideoPackets(PVOID args)
     STATUS status;
     UINT32 i;
     UINT64 startTime, lastFrameTime, elapsed;
+    UINT64 videoFrameDuration;
+    PCHAR pFrameRate;
     PCHAR pNoLoopFrames;
     BOOL noLoopFrames;
     MEMSET(&encoderStats, 0x00, SIZEOF(RtcEncoderStats));
     CHK_ERR(pSampleConfiguration != NULL, STATUS_NULL_ARG, "[KVS Master] Streaming session is NULL");
+
+    // Determine FPS from environment variable, defaulting to DEFAULT_FPS_VALUE (30)
+    pFrameRate = GETENV("CANARY_FRAME_RATE");
+    if (pFrameRate != NULL && pFrameRate[0] != '\0') {
+        UINT64 fps = (UINT64) strtoull(pFrameRate, NULL, 10);
+        if (fps > 0 && fps <= 120) {
+            videoFrameDuration = HUNDREDS_OF_NANOS_IN_A_SECOND / fps;
+            DLOGI("[KVS Master] Using configured frame rate: %llu fps (frame duration: %llu)", fps, videoFrameDuration);
+        } else {
+            videoFrameDuration = SAMPLE_VIDEO_FRAME_DURATION;
+            DLOGW("[KVS Master] Invalid CANARY_FRAME_RATE '%s', using default %u fps", pFrameRate, DEFAULT_FPS_VALUE);
+        }
+    } else {
+        videoFrameDuration = SAMPLE_VIDEO_FRAME_DURATION;
+        DLOGI("[KVS Master] No CANARY_FRAME_RATE set, using default %u fps", DEFAULT_FPS_VALUE);
+    }
 
     frame.presentationTs = 0;
     startTime = GETTIME();
@@ -264,7 +282,7 @@ PVOID sendVideoPackets(PVOID args)
         encoderStats.width = 640;
         encoderStats.height = 480;
         encoderStats.targetBitrate = 262000;
-        frame.presentationTs += SAMPLE_VIDEO_FRAME_DURATION;
+        frame.presentationTs += videoFrameDuration;
         MUTEX_LOCK(pSampleConfiguration->streamingSessionListReadLock);
 
         for (i = 0; i < pSampleConfiguration->streamingSessionCount; ++i) {
@@ -307,10 +325,10 @@ PVOID sendVideoPackets(PVOID args)
 
         // Adjust sleep in the case the sleep itself and writeFrame take longer than expected. Since sleep makes sure that the thread
         // will be paused at least until the given amount, we can assume that there's no too early frame scenario.
-        // Also, it's very unlikely to have a delay greater than SAMPLE_VIDEO_FRAME_DURATION, so the logic assumes that this is always
+        // Also, it's very unlikely to have a delay greater than videoFrameDuration, so the logic assumes that this is always
         // true for simplicity.
         elapsed = lastFrameTime - startTime;
-        THREAD_SLEEP(SAMPLE_VIDEO_FRAME_DURATION - elapsed % SAMPLE_VIDEO_FRAME_DURATION);
+        THREAD_SLEEP(videoFrameDuration - elapsed % videoFrameDuration);
         lastFrameTime = GETTIME();
     }
 


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*Description of changes:*

**StorageLowFps test (10 fps):**
- Modified `sendVideoPackets()` in `kvsWebRTCClientMaster.cpp` to read `CANARY_FRAME_RATE` env var at runtime, falling back to default 30 fps when unset
- Added `STORAGE_FPS` parameter to `runner.groovy` and `gamma_runner.groovy`, passed through as `CANARY_FRAME_RATE` to the storage master binary
- Added `STORAGE_FPS` to reschedule params in both runners to preserve FPS across rescheduled runs
- Added `StorageLowFps` build block in `orchestrator.groovy` (prod) with `STORAGE_FPS=10`
- Added `StorageLowFps` stage in `gamma_orchestrator.groovy` with `RUN_STORAGE_LOW_FPS` toggle
- Added `StorageLowFps` and `GammaStorageLowFps` labels to consumer-java's `CanaryConstants.java` and routed them to the periodic code path in `WebrtcStorageCanaryConsumer.java`

**Fix outbound RTP metrics (FramesPerSecond always 0):**
- Added `prevPliCount` field to `Peer.h`'s `OutgoingRTPMetricsContext` to match `Samples.h`'s layout
- Root cause: the storage master's struct had an extra `prevPliCount` field that `Peer.h` was missing, causing `reinterpret_cast` to read all subsequent fields at an 8-byte offset
- This fixes `FramesPerSecond`, `PercentageFrameDiscarded`, `NackPerSecond`, and `PercentageFramesRetransmitted` metrics which were all reading incorrect values

**Existing tests unaffected:** no `STORAGE_FPS` is set for existing jobs, so they continue using the default 30 fps.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
