### PR TITLE
Phase 1: WebRTC C Master and Single JS Viewer canary test

### DIFF
--- a/canary/webrtc-c/jobs/orchestrator.groovy
+++ b/canary/webrtc-c/jobs/orchestrator.groovy
@@ -6,6 +6,7 @@ PERIODIC_PROFILING_DURATION_IN_SECONDS = 90
 LONG_RUNNING_DURATION_IN_SECONDS = 0
 
 STORAGE_PERIODIC_DURATION_IN_SECONDS = 300 // 5 min
+STORAGE_WITH_VIEWER_DURATION_IN_SECONDS = 600 // 10 min
 STORAGE_SUB_RECONNECT_DURATION_IN_SECONDS = 2700 // 45 min
 STORAGE_SINGLE_RECONNECT_DURATION_IN_SECONDS = 3900 // 65 min
 STORAGE_EXTENDED_DURATION_IN_SECONDS = 43200 // 12 hr
@@ -383,6 +384,52 @@ pipeline {
                                 string(name: 'CONSUMER_NODE_LABEL', value: "webrtc-storage-consumer"),
                                 string(name: 'RUNNER_LABEL', value: "StorageExtended"),
                                 string(name: 'SCENARIO_LABEL', value: "StorageExtended"),
+                                string(name: 'AWS_DEFAULT_REGION', value: "us-west-2"),
+                            ],
+                            wait: false
+                        )
+
+
+                        //Storage with a viewer join
+                        build (
+                            job: NEXT_AVAILABLE_RUNNER,
+                            parameters: COMMON_PARAMS + [
+                                booleanParam(name: 'IS_SIGNALING', value: false),
+                                booleanParam(name: 'IS_STORAGE', value: false),
+                                booleanParam(name: 'IS_STORAGE_SINGLE_NODE', value: false),
+                                booleanParam(name: 'USE_TURN', value: false),
+                                booleanParam(name: 'TRICKLE_ICE', value: false),
+                                booleanParam(name: 'USE_IOT', value: false),
+                                booleanParam(name: 'JS_STORAGE_VIEWER_JOIN', value: true),
+                                string(name: 'DURATION_IN_SECONDS', value: STORAGE_WITH_VIEWER_DURATION_IN_SECONDS.toString()),
+                                string(name: 'MASTER_NODE_LABEL', value: "webrtc-storage-master-2"),
+                                string(name: 'STORAGE_VIEWER_NODE_LABEL', value: "webrtc-storage-viewer"),
+                                string(name: 'RUNNER_LABEL', value: "StorageWithViewer"),
+                                string(name: 'SCENARIO_LABEL', value: "StorageWithViewer"),
+                                string(name: 'AWS_DEFAULT_REGION', value: "us-west-2"),
+                            ],
+                            wait: false
+                        )
+
+                        //Storage with two viewers join
+                        build (
+                            job: NEXT_AVAILABLE_RUNNER,
+                            parameters: COMMON_PARAMS + [
+                                booleanParam(name: 'IS_SIGNALING', value: false),
+                                booleanParam(name: 'IS_STORAGE', value: false),
+                                booleanParam(name: 'IS_STORAGE_SINGLE_NODE', value: false),
+                                booleanParam(name: 'USE_TURN', value: false),
+                                booleanParam(name: 'TRICKLE_ICE', value: false),
+                                booleanParam(name: 'USE_IOT', value: false),
+                                booleanParam(name: 'JS_STORAGE_VIEWER_JOIN', value: false),
+                                booleanParam(name: 'JS_STORAGE_TWO_VIEWERS', value: true),
+                                string(name: 'DURATION_IN_SECONDS', value: STORAGE_WITH_VIEWER_DURATION_IN_SECONDS.toString()),
+                                string(name: 'MASTER_NODE_LABEL', value: "webrtc-storage-master-2"),
+                                string(name: 'STORAGE_VIEWER_NODE_LABEL', value: "webrtc-storage-viewer"),
+                                string(name: 'STORAGE_VIEWER_ONE_NODE_LABEL', value: "webrtc-storage-multi-viewer-1"),
+                                string(name: 'STORAGE_VIEWER_TWO_NODE_LABEL', value: "webrtc-storage-multi-viewer-2"),
+                                string(name: 'RUNNER_LABEL', value: "StorageTwoViewers"),
+                                string(name: 'SCENARIO_LABEL', value: "StorageTwoViewers"),
                                 string(name: 'AWS_DEFAULT_REGION', value: "us-west-2"),
                             ],
                             wait: false

--- a/canary/webrtc-c/jobs/runner.groovy
+++ b/canary/webrtc-c/jobs/runner.groovy
@@ -263,6 +263,8 @@ pipeline {
         string(name: 'GIT_URL')
         string(name: 'GIT_HASH')
         booleanParam(name: 'FIRST_ITERATION', defaultValue: true)
+        booleanParam(name: 'JS_STORAGE_VIEWER_JOIN', defaultValue: false)
+        booleanParam(name: 'JS_STORAGE_TWO_VIEWERS', defaultValue: false)
     }
     
     // Set the role ARN to environment to avoid string interpolation to follow Jenkins security guidelines.
@@ -308,7 +310,8 @@ pipeline {
                     equals expected: false, actual: params.IS_SIGNALING
                     equals expected: false, actual: params.IS_STORAGE
                     equals expected: false, actual: params.IS_STORAGE_SINGLE_NODE 
-
+                    equals expected: false, actual: params.JS_STORAGE_VIEWER_JOIN
+                    equals expected: false, actual: params.JS_STORAGE_TWO_VIEWERS 
                 }
             }
             parallel {
@@ -364,7 +367,9 @@ pipeline {
                 allOf {
                     equals expected: false, actual: params.IS_SIGNALING
                     equals expected: true, actual: params.IS_STORAGE
-                    equals expected: false, actual: params.IS_STORAGE_SINGLE_NODE 
+                    equals expected: false, actual: params.IS_STORAGE_SINGLE_NODE
+                    equals expected: false, actual: params.JS_STORAGE_VIEWER_JOIN
+                    equals expected: false, actual: params.JS_STORAGE_TWO_VIEWERS 
                 }
             }
             parallel {
@@ -416,6 +421,134 @@ pipeline {
             }
         }
 
+        stage('Build and Run Webrtc-storage Viewer') {
+            failFast true
+            when {
+                equals expected: true, actual: params.JS_STORAGE_VIEWER_JOIN
+            }
+            parallel {
+                stage('StorageMaster') {
+                    agent {
+                        label params.MASTER_NODE_LABEL
+                    }                    
+                    steps {
+                        script {
+                            
+                            buildStorageCanary(false, params)
+                        }
+                    }
+                }
+                stage('StorageViewer') {
+                    agent {
+                        label params.STORAGE_VIEWER_NODE_LABEL
+                    }
+                    steps {
+                        script {
+                            
+                            sh """
+                                echo "DEBUG: Checking StorageViewer directory contents"
+                                echo "DEBUG: GIT_HASH parameter: ${params.GIT_HASH}"
+                                git rev-parse HEAD
+                                ls -la ./canary/webrtc-c/scripts/
+                                pwd
+                            """
+                            
+                            try {
+                                sh """
+                                    export JOB_NAME="${env.JOB_NAME}"
+                                    export RUNNER_LABEL="${params.RUNNER_LABEL}"
+                                    export AWS_DEFAULT_REGION="${params.AWS_DEFAULT_REGION}"
+                                    export DURATION_IN_SECONDS="${params.DURATION_IN_SECONDS}"
+                                    export FORCE_TURN="${params.FORCE_TURN}"
+                                    export VIEWER_COUNT="${params.VIEWER_COUNT}"
+                                    
+                                    ./canary/webrtc-c/scripts/setup-storage-viewer.sh
+                                """
+                            } catch (FlowInterruptedException err) {
+                                echo 'Aborted due to cancellation'
+                                throw err
+                            } catch (err) {
+                                HAS_ERROR = true
+                                unstable err.toString()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        stage('Build and Run Webrtc-storage Two Viewers') {
+            failFast true
+            when {
+                equals expected: true, actual: params.JS_STORAGE_TWO_VIEWERS
+            }
+            parallel {
+                stage('StorageMaster') {
+                    agent {
+                        label params.MASTER_NODE_LABEL
+                    }                    
+                    steps {
+                        script {
+                            buildStorageCanary(false, params)
+                        }
+                    }
+                }
+                stage('StorageViewer1') {
+                    agent {
+                        label params.STORAGE_VIEWER_ONE_NODE_LABEL
+                    }
+                    steps {
+                        script {
+                            
+                            try {
+                                sh """
+                                    export JOB_NAME="${env.JOB_NAME}"
+                                    export RUNNER_LABEL="${params.RUNNER_LABEL}"
+                                    export AWS_DEFAULT_REGION="${params.AWS_DEFAULT_REGION}"
+                                    export DURATION_IN_SECONDS="${params.DURATION_IN_SECONDS}"
+                                    export FORCE_TURN="${params.FORCE_TURN}"
+                                    
+                                    ./canary/webrtc-c/scripts/setup-storage-viewer.sh
+                                """
+                            } catch (FlowInterruptedException err) {
+                                echo 'Aborted due to cancellation'
+                                throw err
+                            } catch (err) {
+                                HAS_ERROR = true
+                                unstable err.toString()
+                            }
+                        }
+                    }
+                }
+                stage('StorageViewer2') {
+                    agent {
+                        label params.STORAGE_VIEWER_TWO_NODE_LABEL
+                    }
+                    steps {
+                        script {         
+                            try {
+                                sh """
+                                    export JOB_NAME="${env.JOB_NAME}"
+                                    export RUNNER_LABEL="${params.RUNNER_LABEL}"
+                                    export AWS_DEFAULT_REGION="${params.AWS_DEFAULT_REGION}"
+                                    export DURATION_IN_SECONDS="${params.DURATION_IN_SECONDS}"
+                                    export FORCE_TURN="${params.FORCE_TURN}"
+                                    
+                                    ./canary/webrtc-c/scripts/setup-storage-viewer.sh
+                                """
+                            } catch (FlowInterruptedException err) {
+                                echo 'Aborted due to cancellation'
+                                throw err
+                            } catch (err) {
+                                HAS_ERROR = true
+                                unstable err.toString()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         stage('Unset credentials') {
             steps {
                 script {
@@ -449,6 +582,9 @@ pipeline {
                       booleanParam(name: 'IS_SIGNALING', value: params.IS_SIGNALING),
                       booleanParam(name: 'IS_STORAGE', value: params.IS_STORAGE),
                       booleanParam(name: 'IS_STORAGE_SINGLE_NODE', value: params.IS_STORAGE_SINGLE_NODE),
+                      booleanParam(name: 'JS_STORAGE_VIEWER_JOIN', value: params.JS_STORAGE_VIEWER_JOIN),
+                      booleanParam(name: 'JS_STORAGE_TWO_VIEWERS', value: params.JS_STORAGE_TWO_VIEWERS),
+                      booleanParam(name: 'JS_STORAGE_THREE_VIEWERS', value: params.JS_STORAGE_THREE_VIEWERS),
                       booleanParam(name: 'USE_TURN', value: params.USE_TURN),
                       booleanParam(name: 'FORCE_TURN', value: params.FORCE_TURN),
                       booleanParam(name: 'USE_IOT', value: params.USE_IOT),

--- a/canary/webrtc-c/scripts/chrome-headless.js
+++ b/canary/webrtc-c/scripts/chrome-headless.js
@@ -1,0 +1,470 @@
+const puppeteer = require('puppeteer');
+const { CloudWatchClient } = require('@aws-sdk/client-cloudwatch');
+const { CloudWatchMetrics } = require('./cloudwatch');
+const fs = require('fs');
+
+function log(message) {
+  const timestamp = new Date().toISOString();
+  console.log(`[${timestamp}] ${message}`);
+}
+
+class ViewerCanaryTest {
+  constructor(config) {
+    this.config = config;
+    log(`Initializing test with single viewer`);
+    
+    this.sessionStartTime = Date.now();
+    this.storageSessionJoined = false;
+    this.screenshotTaken = false;
+    this.framesReceived = false;
+    this.testCompleted = false;
+    this.timerStarted = false;
+    
+    this.browser = null;
+    this.page = null;
+  }
+
+  async initializeCloudWatch() {
+    const cwClient = new CloudWatchClient({ region: this.config.region || 'us-west-2' });
+    CloudWatchMetrics.init(cwClient);
+  }
+
+  async createBrowser() {
+    return await puppeteer.launch({ 
+      headless: true,
+      args: ['--use-fake-ui-for-media-stream', '--use-fake-device-for-media-stream']
+    });
+  }
+
+  setupConsoleListener(page) {
+    page.on('console', async (msg) => {
+      const text = msg.text();
+      log(`PAGE: ${text}`);
+      
+      if (text.includes('Successfully joined the storage session')) {
+        log('Storage session joined - ready to monitor frames!');
+        this.storageSessionJoined = true;
+        
+        if (this.config.saveScreenshots) {
+          await page.screenshot({ path: `storage-session-active-${Date.now()}.png` });
+          log('Screenshot saved!');
+        }
+        this.screenshotTaken = true;
+        
+        const joinTime = Date.now() - this.sessionStartTime;
+        await CloudWatchMetrics.publishMsMetric(
+          'JoinSSAsViewerTime',
+          this.config.channelName,
+          joinTime
+        );
+      }
+    });
+  }
+
+  validateEnvironment() {
+    if (!process.env.AWS_ACCESS_KEY_ID) {
+      throw new Error('AWS_ACCESS_KEY_ID environment variable not set');
+    }
+  }
+
+  buildTestUrl() {
+    const params = new URLSearchParams({
+      channelName: this.config.channelName,
+      region: this.config.region || 'us-west-2',
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+      sessionToken: process.env.AWS_SESSION_TOKEN || '',
+      sendVideo: this.config.sendVideo || 'false',
+      sendAudio: this.config.sendAudio || 'false',
+    });
+    
+    // Add forceTURN parameter if configured
+    if (this.config.forceTURN === true) {
+      params.set('forceTURN', 'true');
+    }
+    
+    return `https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-js/examples/index.html?${params}`;
+  }
+
+  async waitForChannel() {
+    log('Waiting 2 minutes for master to create channel...');
+    await new Promise(resolve => setTimeout(resolve, 120000));
+  }
+
+  async initializePage(page) {
+    const url = this.buildTestUrl();
+    log(`Opening URL: ${url}`);
+    
+    await page.goto(url);
+    await page.evaluate(() => {
+      document.querySelector('#ingest-media-manual-on').setAttribute('data-selected', 'true');
+    });
+    
+    log('Page loaded, clicking viewer button...');
+    await page.click('#viewer-button');
+  }
+
+  async waitForViewerStart(page) {
+    log('Waiting for viewer to start...');
+    const maxRetries = 3;
+    
+    for (let retry = 0; retry < maxRetries; retry++) {
+      if (retry > 0) {
+        log(`Retry ${retry}: Restarting viewer...`);
+        await page.click('#viewer-button');
+      }
+      
+      const startTimeout = 60000;
+      const startTime = Date.now();
+      
+      while ((Date.now() - startTime) < startTimeout) {
+        const status = await page.evaluate(() => ({
+          viewerExists: !!(window.viewer),
+          connectionState: window.viewer?.pc?.iceConnectionState,
+          signalingState: window.viewer?.pc?.signalingState,
+          error: window.viewer?.error
+        }));
+        
+        if (status.viewerExists && !status.error) {
+          log('Viewer started successfully!');
+          log(`Connection state: ${status.connectionState}`);
+          log(`Signaling state: ${status.signalingState}`);
+          return true;
+        }
+        
+        if (status.error) {
+          log('Viewer error detected, will retry...');
+          break;
+        }
+        
+        await new Promise(resolve => setTimeout(resolve, 1000));
+      }
+    }
+    
+    throw new Error('Viewer failed to start after 3 retries');
+  }
+
+  async waitForStorageSession() {
+    log('Waiting for storage session to be joined...');
+    const sessionTimeout = 180000;
+    
+    while (!this.storageSessionJoined && (Date.now() - this.sessionStartTime) < sessionTimeout) {
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+    
+    if (!this.storageSessionJoined) {
+      throw new Error('Storage session not joined within 180 seconds');
+    }
+  }
+
+  async getFrameStats(page) {
+    return await page.evaluate(() => {
+      const viewerExists = !!(window.viewer);
+      const remoteViewElements = document.querySelectorAll('.remote-view');
+      
+      let hasActiveVideo = false;
+      let videoInfo = [];
+      
+      remoteViewElements.forEach((video) => {
+        if (video.srcObject && video.readyState >= 2) {
+          hasActiveVideo = true;
+          videoInfo.push({
+            videoWidth: video.videoWidth,
+            videoHeight: video.videoHeight,
+            readyState: video.readyState,
+          });
+        }
+      });
+      
+      let storageSessionActive = false;
+      let signalingConnected = false;
+      
+      if (window.viewer) {
+        signalingConnected = window.viewer.signalingClient?.readyState === 1;
+        storageSessionActive = !!(window.viewer.storageSessionJoined || 
+                                window.viewer.isStorageSessionActive ||
+                                (window.viewer.signalingClient && signalingConnected));
+      }
+      
+      return {
+        viewerExists,
+        storageSessionActive,
+        signalingConnected,
+        connectionState: signalingConnected ? 'connected' : 'disconnected',
+        hasActiveVideo,
+        remoteViewCount: remoteViewElements.length,
+        videoInfo,
+        timestamp: Date.now()
+      };
+    });
+  }
+
+  async captureVideoFrame(page) {
+    return await page.evaluate(() => {
+      const remoteVideo = document.querySelector('.remote-view');
+      if (remoteVideo && remoteVideo.videoWidth > 0) {
+        const canvas = document.createElement('canvas');
+        canvas.width = remoteVideo.videoWidth;
+        canvas.height = remoteVideo.videoHeight;
+        const ctx = canvas.getContext('2d');
+        ctx.drawImage(remoteVideo, 0, 0);
+        return {
+          dataURL: canvas.toDataURL('image/png'),
+          width: canvas.width,
+          height: canvas.height
+        };
+      }
+      return null;
+    });
+  }
+
+  async handleVideoDetection(page) {
+    log('SUCCESS: Active video detected!');
+    
+    const frameData = await this.captureVideoFrame(page);
+    if (frameData) {
+      log(`First frame detected: ${frameData.width}x${frameData.height}`);
+      
+      if (this.config.saveFrames) {
+        if (!fs.existsSync('frames')) fs.mkdirSync('frames');
+        const base64Data = frameData.dataURL.replace(/^data:image\/png;base64,/, '');
+        fs.writeFileSync(`frames/first-frame-${Date.now()}.png`, base64Data, 'base64');
+        log('First frame saved!');
+      }
+    }
+    
+    const frameDetectionTime = Date.now() - this.sessionStartTime;
+    await CloudWatchMetrics.publishMsMetric(
+      'TimeToFirstFrame',
+      this.config.channelName,
+      frameDetectionTime
+    );
+    
+    this.framesReceived = true;
+  }
+
+  async monitorConnection(page) {
+    log('Storage session joined! Now monitoring connection state...');
+    let lastStatusLog = 0;
+    const statusLogInterval = 10000;
+    
+    while (!this.testCompleted) {
+      const frameStats = await this.getFrameStats(page);
+      
+      if (frameStats.hasActiveVideo && !this.framesReceived) {
+        await this.handleVideoDetection(page);
+      }
+      
+      if (frameStats.storageSessionActive && !this.timerStarted) {
+        log('Storage session active!');
+        this.timerStarted = true;
+        
+        log(`Storage session active, running test for 20 seconds...`);
+        setTimeout(() => {
+          this.testCompleted = true;
+        }, 20000);
+      }
+      
+      if (!frameStats.viewerExists) {
+        log('Viewer object lost!');
+        this.testCompleted = true;
+        break;
+      }
+      
+      const now = Date.now();
+      if (now - lastStatusLog >= statusLogInterval) {
+        const elapsed = Math.floor((now - this.sessionStartTime) / 1000);
+        log(`[${elapsed}s]ActiveVideo: ${frameStats.hasActiveVideo}`);
+        lastStatusLog = now;
+      }
+      
+      await new Promise(resolve => setTimeout(resolve, 2000));
+    }
+  }
+
+  getTestResults() {
+    const metrics = {
+      success: this.storageSessionJoined,
+      storageSessionJoined: this.storageSessionJoined,
+      framesReceived: this.framesReceived,
+      timestamp: Date.now()
+    };
+    
+    log(metrics.success ? 'TEST PASSED: Storage session joined successfully' : 'TEST FAILED: Storage session not joined');
+    log('Test completed!');
+    log(`Final metrics: ${JSON.stringify(metrics)}`);
+    
+    const success = metrics.success && this.framesReceived;
+    log(success ? 'TEST PASSED: Frames received successfully' : 'TEST FAILED: No frames received');
+    
+    return { ...metrics, success, framesReceived: this.framesReceived };
+  }
+}
+
+async function runViewerCanary(config) {
+  log('Starting viewer canary test...');
+  log(`Config: ${JSON.stringify(config)}`);
+  
+  const test = new ViewerCanaryTest(config);
+  
+  // Cleanup function to properly close viewer
+  const cleanup = async (reason = 'normal') => {
+    try {
+      log(`Cleaning up viewer connection (${reason})...`);
+      
+      if (test.page) {
+        try {
+          // Try to click stop viewer button for proper cleanup
+          const stopButtonClicked = await test.page.evaluate(() => {
+            const stopButton = document.querySelector('#stop-viewer-button');
+            if (stopButton && !stopButton.disabled) {
+              stopButton.click();
+              return true;
+            }
+            return false;
+          }).catch(() => false);
+          
+          if (stopButtonClicked) {
+            log(`Stop viewer button clicked successfully`);
+          } else {
+            log(`Stop viewer button not found, attempting manual cleanup`);
+            // Manual cleanup if button doesn't exist
+            await test.page.evaluate(() => {
+              if (window.viewer && window.viewer.signalingClient) {
+                try {
+                  window.viewer.signalingClient.close();
+                  console.log('Manually closed signaling client');
+                } catch (e) {
+                  console.log('Error closing signaling client:', e);
+                }
+              }
+            }).catch(() => {});
+          }
+        } catch (error) {
+          log(`Error cleaning up viewer: ${error.message}`);
+        }
+      }
+      
+      // Wait a moment for cleanup
+      await new Promise(resolve => setTimeout(resolve, 1000));
+      
+      // Close browser
+      if (test.browser) {
+        try {
+          await test.browser.close();
+          log(`Browser closed successfully`);
+        } catch (error) {
+          log(`Error closing browser: ${error.message}`);
+        }
+      }
+      
+    } catch (error) {
+      log(`Error during cleanup: ${error.message}`);
+    }
+  };
+
+  // Two-stage timeout approach: cleanup timeout + hard timeout
+  let cleanupCompleted = false;
+  
+  const performCleanup = async () => {
+    if (cleanupCompleted) return;
+    cleanupCompleted = true;
+    
+    try {
+      log('Timeout approaching - performing cleanup...');
+      
+      // Try to stop viewer
+      if (test.page) {
+        try {
+          await test.page.click('#stop-viewer-button');
+          log(`Stop Viewer button clicked successfully`);
+        } catch (error) {
+          log(`Cleanup failed: ${error.message}`);
+        }
+      }
+      
+      await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for cleanup
+    } catch (error) {
+      log(`Cleanup failed: ${error.message}`);
+    }
+  };
+
+  const cleanupTimeout = (config.duration - 10) * 1000; // Start cleanup 10 seconds early
+  const hardTimeout = config.duration * 1000; // Hard timeout
+
+  const cleanupPromise = new Promise((_, reject) => {
+    setTimeout(async () => {
+      await performCleanup();
+      reject(new Error('Test timeout - cleanup completed'));
+    }, cleanupTimeout);
+  });
+
+  const hardTimeoutPromise = new Promise((_, reject) => {
+    setTimeout(() => {
+      reject(new Error('Hard timeout exceeded'));
+    }, hardTimeout);
+  });
+  
+  try {
+    const results = await Promise.race([
+      (async () => {
+        await test.initializeCloudWatch();
+        test.validateEnvironment();
+        // await test.waitForChannel();
+        
+        // Create and initialize single browser and page
+        log(`Creating viewer instance...`);
+        
+        test.browser = await test.createBrowser();
+        test.page = await test.browser.newPage();
+        
+        test.setupConsoleListener(test.page);
+        await test.initializePage(test.page);
+        
+        log('Starting viewer...');
+        
+        await test.waitForViewerStart(test.page);
+        
+        await test.waitForStorageSession();
+        
+        // Monitor the viewer
+        await test.monitorConnection(test.page);
+        
+        cleanupCompleted = true; // Mark cleanup as not needed (normal completion)
+        return test.getTestResults();
+      })(),
+      cleanupPromise,
+      hardTimeoutPromise
+    ]);
+    
+    await cleanup('normal');
+    return results;
+    
+  } catch (error) {
+    log(`Error running viewer canary: ${error.message}`);
+    
+    // If cleanup hasn't been performed yet (e.g., hard timeout), do it now
+    if (!cleanupCompleted) {
+      await performCleanup();
+    }
+    
+    const isTimeout = error.message.includes('timeout');
+    await cleanup(isTimeout ? 'timeout' : 'error');
+    throw error;
+  }
+}
+
+// Run the test
+runViewerCanary({
+  channelName: process.env.CANARY_CHANNEL_NAME || 'ScaryTestStream',
+  region: process.env.AWS_REGION || 'us-west-2',
+  duration: parseInt(process.env.TEST_DURATION) || 360,
+  saveFrames: process.env.SAVE_FRAMES === 'true',
+  clientId: process.env.CLIENT_ID || `test-viewer-${Date.now()}`,
+  forceTURN: process.env.FORCE_TURN === 'true'
+}).then(result => {
+  process.exit(result.success ? 0 : 1);
+}).catch(error => {
+  log(`Test failed with error: ${error.message}`);
+  process.exit(1);
+});

--- a/canary/webrtc-c/scripts/cloudwatch.js
+++ b/canary/webrtc-c/scripts/cloudwatch.js
@@ -1,0 +1,42 @@
+const { CloudWatchClient, PutMetricDataCommand } = require("@aws-sdk/client-cloudwatch");
+
+class CloudWatchMetrics {
+    static cwClient;
+    
+    static init(cwClient) {
+        this.cwClient = cwClient;
+    }
+    
+    static async publishMsMetric(metricName, channelName, msValue, when = Date.now()) {
+        if (!this.cwClient || !channelName) {
+            return msValue;
+        }
+
+        const msMetric = {
+            MetricName: metricName,
+            Dimensions: [{
+                Name: 'StorageWithViewerChannelName',
+                Value: channelName,
+            }],
+            Timestamp: new Date(when),
+            Value: msValue,
+            Unit: 'Milliseconds'
+        };
+
+        const commandInput = {
+            Namespace: 'ViewerApplication',
+            MetricData: [msMetric],
+        };
+
+        const command = new PutMetricDataCommand(commandInput);
+        try {
+            await this.cwClient.send(command);
+            console.log(metricName, 'sent to cloudwatch!');
+        } catch (e) {
+            console.error(e);
+        }
+        return msValue;
+    }
+}
+
+module.exports = { CloudWatchMetrics };

--- a/canary/webrtc-c/scripts/setup-storage-viewer.sh
+++ b/canary/webrtc-c/scripts/setup-storage-viewer.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Wait for StorageMaster to start up
+echo "Waiting 1 minute for StorageMaster to start..."
+sleep 60
+
+# Install Node.js if not present with retry logic
+if ! command -v npm &> /dev/null; then
+    echo "Node.js not found, installing..."
+    for i in {1..3}; do
+        if curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash - && sudo apt-get install -y nodejs; then
+            break
+        else
+            echo "Installation attempt $i failed, retrying in 10 seconds..."
+            sleep 10
+        fi
+    done
+    echo "Node.js installation completed"
+else
+    echo "Node.js already installed: $(node --version)"
+fi
+
+cd ./canary/webrtc-c/scripts || { echo "ERROR: Failed to change directory to ./canary/webrtc-c/scripts"; exit 1; }
+
+# Install Node.js dependencies if not exists
+if [ ! -d "node_modules" ]; then
+    npm install puppeteer @aws-sdk/client-cloudwatch || { echo "ERROR: Failed to install Node.js dependencies"; exit 1; }
+fi
+
+# Set environment variables for the test
+export CANARY_CHANNEL_NAME="${JOB_NAME}-${RUNNER_LABEL}"
+export AWS_REGION="${AWS_DEFAULT_REGION}"
+export TEST_DURATION="${DURATION_IN_SECONDS}"
+
+# Run storage viewer test
+node chrome-headless.js || { echo "ERROR: Chrome headless test failed"; exit 1; }


### PR DESCRIPTION
*Description of changes:*

_What changes are made_

- New end-to-end test: C Master streams video+audio to KVS storage while a headless JS Viewer joins the storage session and validates video reception
- New CloudWatch metric: `JoinSSAsViewerTime` — time for JS viewer to successfully join the storage session
- New orchestrator job `StorageWithViewer` with 10-min duration, dedicated node, and auto-reschedule
- Viewer runs on a separate Jenkins agent with its own workspace

_How those changes are made_
- `chrome-headless.js` — Puppeteer-based script that opens the KVS WebRTC JS SDK example page, clicks the viewer button, joins the storage session, and validates frames are received
- `cloudwatch.js` — helper module to publish metrics to CloudWatch from the Node.js viewer script
- `setup-storage-viewer.sh` — installs Node.js 20+, npm dependencies, and Puppeteer browsers on the viewer node (with retry logic)
- `runner.groovy` — new parallel stage `Build and Run Webrtc-storage Viewer` that runs C Master + JS Viewer on separate nodes
- `orchestrator.groovy` — schedules `StorageWithViewer` with `wait: false` for parallel execution
- **Efforts made for reliability**
  - 3-retry mechanism if viewer fails to start or detects an error
  - Two-stage timeout: cleanup starts 10s before hard timeout (stop-viewer button clicked before browser exits)
  - 60s wait for master channel creation before viewer attempts to connect
  - `forceTURN` parameter support for network path testing
  - Timestamped logging for all viewer output


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
