### PR TITLE
Phase 2: WebRTC C Master and Multiple JS Viewers

### DIFF
--- a/canary/webrtc-c/jobs/orchestrator.groovy
+++ b/canary/webrtc-c/jobs/orchestrator.groovy
@@ -434,6 +434,32 @@ pipeline {
                             ],
                             wait: false
                         )
+
+                        //Storage with three viewers join
+                        build (
+                            job: NEXT_AVAILABLE_RUNNER,
+                            parameters: COMMON_PARAMS + [
+                                booleanParam(name: 'IS_SIGNALING', value: false),
+                                booleanParam(name: 'IS_STORAGE', value: false),
+                                booleanParam(name: 'IS_STORAGE_SINGLE_NODE', value: false),
+                                booleanParam(name: 'USE_TURN', value: false),
+                                booleanParam(name: 'TRICKLE_ICE', value: false),
+                                booleanParam(name: 'USE_IOT', value: false),
+                                booleanParam(name: 'JS_STORAGE_VIEWER_JOIN', value: false),
+                                booleanParam(name: 'JS_STORAGE_TWO_VIEWERS', value: false),
+                                booleanParam(name: 'JS_STORAGE_THREE_VIEWERS', value: true),
+                                string(name: 'DURATION_IN_SECONDS', value: STORAGE_WITH_VIEWER_DURATION_IN_SECONDS.toString()),
+                                string(name: 'MASTER_NODE_LABEL', value: "webrtc-storage-master-2"),
+                                string(name: 'STORAGE_VIEWER_NODE_LABEL', value: "webrtc-storage-viewer"),
+                                string(name: 'STORAGE_VIEWER_ONE_NODE_LABEL', value: "webrtc-storage-multi-viewer-1"),
+                                string(name: 'STORAGE_VIEWER_TWO_NODE_LABEL', value: "webrtc-storage-multi-viewer-2"),
+                                string(name: 'STORAGE_VIEWER_THREE_NODE_LABEL', value: "webrtc-storage-consumer"),
+                                string(name: 'RUNNER_LABEL', value: "StorageThreeViewers"),
+                                string(name: 'SCENARIO_LABEL', value: "StorageThreeViewers"),
+                                string(name: 'AWS_DEFAULT_REGION', value: "us-west-2"),
+                            ],
+                            wait: false
+                        )
                     }
                 }
 

--- a/canary/webrtc-c/jobs/runner.groovy
+++ b/canary/webrtc-c/jobs/runner.groovy
@@ -20,8 +20,6 @@ def buildWebRTCProject(useMbedTLS, thing_prefix) {
         chmod a+x cert_setup.sh &&
         ./cert_setup.sh ${thing_prefix} &&
         cd .. &&
-        echo "Cleaning up build and open-source directories..." &&
-        rm -rf build open-source &&
         mkdir -p build &&
         cd build &&
         ${configureCmd} &&
@@ -164,6 +162,57 @@ def buildSignaling(params) {
     }
 }
 
+def runViewerSessions(viewerId = "", waitMinutes = 10, viewerCount = "1") {
+    // Create unique workspace for each viewer to prevent Git conflicts
+    def workspaceName = "${env.JOB_NAME}-${viewerId ?: 'viewer'}-${BUILD_NUMBER}"
+    ws(workspaceName) {
+        try {
+            deleteDir()
+            checkout([$class: 'GitSCM', branches: [[name: params.GIT_HASH ]],
+                      userRemoteConfigs: [[url: params.GIT_URL]]])
+            
+            if (params.FIRST_ITERATION) {
+                echo "First iteration - waiting ${waitMinutes} minutes for master to build"
+                sleep waitMinutes * 60
+            }
+            
+            for (int session = 1; session <= 3; session++) {
+                echo "Starting ${viewerId ? viewerId + ' ' : ''}session ${session}/3"
+                
+                try {
+                    sh """
+                        export JOB_NAME="${env.JOB_NAME}"
+                        export RUNNER_LABEL="${params.RUNNER_LABEL}"
+                        export AWS_DEFAULT_REGION="${params.AWS_DEFAULT_REGION}"
+                        export DURATION_IN_SECONDS="180"
+                        export FORCE_TURN="${params.FORCE_TURN}"
+                        export VIEWER_COUNT="${viewerCount}"
+                        export VIEWER_ID="${viewerId}"
+                        export CLIENT_ID="${viewerId ? viewerId.toLowerCase() + '-' : 'viewer-'}session-${session}-${BUILD_NUMBER}"
+                        
+                        ./canary/webrtc-c/scripts/setup-storage-viewer.sh
+                    """
+                } catch (FlowInterruptedException err) {
+                    echo 'Aborted due to cancellation'
+                    throw err
+                } catch (err) {
+                    HAS_ERROR = true
+                    unstable err.toString()
+                }
+                
+                if (session < 3) {
+                    echo "${viewerId ? viewerId + ' ' : ''}session ${session} completed. Waiting 1 minute before next session."
+                    sleep 60
+                }
+            }
+            echo "All 3 ${viewerId ? viewerId + ' ' : ''}sessions completed"
+        } finally {
+            // Ensure complete cleanup
+            deleteDir()
+        }
+    }
+}
+
 def buildStorageCanary(isConsumer, params) {
     def scripts_dir = !isConsumer ? "$WORKSPACE/canary/webrtc-c/scripts" :
         "$WORKSPACE/canary/webrtc-c/scripts"
@@ -255,6 +304,11 @@ pipeline {
         string(name: 'MASTER_NODE_LABEL')
         string(name: 'CONSUMER_NODE_LABEL')
         string(name: 'VIEWER_NODE_LABEL')
+        string(name: 'STORAGE_VIEWER_NODE_LABEL')
+        string(name: 'STORAGE_VIEWER_ONE_NODE_LABEL')
+        string(name: 'STORAGE_VIEWER_TWO_NODE_LABEL')
+        string(name: 'STORAGE_VIEWER_THREE_NODE_LABEL')
+        string(name: 'VIEWER_COUNT')
         string(name: 'RUNNER_LABEL')
         string(name: 'SCENARIO_LABEL')
         string(name: 'DURATION_IN_SECONDS')
@@ -265,6 +319,7 @@ pipeline {
         booleanParam(name: 'FIRST_ITERATION', defaultValue: true)
         booleanParam(name: 'JS_STORAGE_VIEWER_JOIN', defaultValue: false)
         booleanParam(name: 'JS_STORAGE_TWO_VIEWERS', defaultValue: false)
+        booleanParam(name: 'JS_STORAGE_THREE_VIEWERS', defaultValue: false)
     }
     
     // Set the role ARN to environment to avoid string interpolation to follow Jenkins security guidelines.
@@ -273,6 +328,40 @@ pipeline {
     }
 
     stages {
+        stage('Pre Cleanup') {
+            steps {
+                script {
+                    sh """
+                        echo "Cleaning up workspace artifacts - Disk usage before cleanup:"
+                        df -h
+                        
+                        # Clean all @tmp directories older than 1 hour
+                        find ~/Jenkins -name "*@tmp" -type d -mmin +60 -exec rm -rf {} + 2>/dev/null || true
+                        
+                        # Keep only last 10 workspace directories per job
+                        cd ~/Jenkins 2>/dev/null || true
+                        ls -t | grep "webrtc-canary-runner" | grep -v "@tmp" | tail -n +11 | xargs -I {} rm -rf {} 2>/dev/null || true
+                        
+                        # Clean Puppeteer cache (keep only latest Chrome)
+                        find ~/.cache/puppeteer -type d -name "linux-*" 2>/dev/null | sort -r | tail -n +2 | xargs rm -rf 2>/dev/null || true
+                        
+                        # Clean npm cache if over 200MB
+                        if [ -d ~/.npm ] && [ \$(du -sm ~/.npm 2>/dev/null | cut -f1) -gt 200 ]; then
+                            npm cache clean --force 2>/dev/null || true
+                        fi
+                        
+                        # Clean temp files
+                        find /tmp -name "*storage*viewer*" -type d -mmin +60 -exec rm -rf {} + 2>/dev/null || true
+                        find /tmp -name "*webrtc-canary-runner*" -type d -mmin +60 -exec rm -rf {} + 2>/dev/null || true
+                        find /tmp -name "jenkins-*" -type d -mtime +1 -exec rm -rf {} + 2>/dev/null || true
+                        
+                        echo "Cleanup completed - Disk usage after cleanup:"
+                        df -h
+                    """
+                }
+            }
+        }
+
         stage('Fetch STS credentials and export to env vars') {
             steps {
                 script {
@@ -311,7 +400,8 @@ pipeline {
                     equals expected: false, actual: params.IS_STORAGE
                     equals expected: false, actual: params.IS_STORAGE_SINGLE_NODE 
                     equals expected: false, actual: params.JS_STORAGE_VIEWER_JOIN
-                    equals expected: false, actual: params.JS_STORAGE_TWO_VIEWERS 
+                    equals expected: false, actual: params.JS_STORAGE_TWO_VIEWERS
+                    equals expected: false, actual: params.JS_STORAGE_THREE_VIEWERS
                 }
             }
             parallel {
@@ -369,7 +459,8 @@ pipeline {
                     equals expected: true, actual: params.IS_STORAGE
                     equals expected: false, actual: params.IS_STORAGE_SINGLE_NODE
                     equals expected: false, actual: params.JS_STORAGE_VIEWER_JOIN
-                    equals expected: false, actual: params.JS_STORAGE_TWO_VIEWERS 
+                    equals expected: false, actual: params.JS_STORAGE_TWO_VIEWERS
+                    equals expected: false, actual: params.JS_STORAGE_THREE_VIEWERS
                 }
             }
             parallel {
@@ -421,20 +512,20 @@ pipeline {
             }
         }
 
-        stage('Build and Run Webrtc-storage Viewer') {
-            failFast true
+        stage('Single Viewer with Continuous Master') {
             when {
                 equals expected: true, actual: params.JS_STORAGE_VIEWER_JOIN
             }
             parallel {
-                stage('StorageMaster') {
+                stage('Continuous StorageMaster') {
                     agent {
                         label params.MASTER_NODE_LABEL
-                    }                    
+                    }
                     steps {
                         script {
-                            
-                            buildStorageCanary(false, params)
+                            def mutableParams = [:] + params
+                            mutableParams.DURATION_IN_SECONDS = "1380"
+                            buildStorageCanary(false, mutableParams)
                         }
                     }
                 }
@@ -444,52 +535,27 @@ pipeline {
                     }
                     steps {
                         script {
-                            
-                            sh """
-                                echo "DEBUG: Checking StorageViewer directory contents"
-                                echo "DEBUG: GIT_HASH parameter: ${params.GIT_HASH}"
-                                git rev-parse HEAD
-                                ls -la ./canary/webrtc-c/scripts/
-                                pwd
-                            """
-                            
-                            try {
-                                sh """
-                                    export JOB_NAME="${env.JOB_NAME}"
-                                    export RUNNER_LABEL="${params.RUNNER_LABEL}"
-                                    export AWS_DEFAULT_REGION="${params.AWS_DEFAULT_REGION}"
-                                    export DURATION_IN_SECONDS="${params.DURATION_IN_SECONDS}"
-                                    export FORCE_TURN="${params.FORCE_TURN}"
-                                    export VIEWER_COUNT="${params.VIEWER_COUNT}"
-                                    
-                                    ./canary/webrtc-c/scripts/setup-storage-viewer.sh
-                                """
-                            } catch (FlowInterruptedException err) {
-                                echo 'Aborted due to cancellation'
-                                throw err
-                            } catch (err) {
-                                HAS_ERROR = true
-                                unstable err.toString()
-                            }
+                            runViewerSessions("", 55, "1")
                         }
                     }
                 }
             }
         }
 
-        stage('Build and Run Webrtc-storage Two Viewers') {
-            failFast true
+        stage('Two Viewers with Continuous Master') {
             when {
                 equals expected: true, actual: params.JS_STORAGE_TWO_VIEWERS
             }
             parallel {
-                stage('StorageMaster') {
+                stage('Continuous StorageMaster') {
                     agent {
                         label params.MASTER_NODE_LABEL
-                    }                    
+                    }
                     steps {
                         script {
-                            buildStorageCanary(false, params)
+                            def mutableParams = [:] + params
+                            mutableParams.DURATION_IN_SECONDS = "1380"
+                            buildStorageCanary(false, mutableParams)
                         }
                     }
                 }
@@ -499,24 +565,7 @@ pipeline {
                     }
                     steps {
                         script {
-                            
-                            try {
-                                sh """
-                                    export JOB_NAME="${env.JOB_NAME}"
-                                    export RUNNER_LABEL="${params.RUNNER_LABEL}"
-                                    export AWS_DEFAULT_REGION="${params.AWS_DEFAULT_REGION}"
-                                    export DURATION_IN_SECONDS="${params.DURATION_IN_SECONDS}"
-                                    export FORCE_TURN="${params.FORCE_TURN}"
-                                    
-                                    ./canary/webrtc-c/scripts/setup-storage-viewer.sh
-                                """
-                            } catch (FlowInterruptedException err) {
-                                echo 'Aborted due to cancellation'
-                                throw err
-                            } catch (err) {
-                                HAS_ERROR = true
-                                unstable err.toString()
-                            }
+                            runViewerSessions("Viewer1", 55, "2")
                         }
                     }
                 }
@@ -525,26 +574,84 @@ pipeline {
                         label params.STORAGE_VIEWER_TWO_NODE_LABEL
                     }
                     steps {
-                        script {         
-                            try {
-                                sh """
-                                    export JOB_NAME="${env.JOB_NAME}"
-                                    export RUNNER_LABEL="${params.RUNNER_LABEL}"
-                                    export AWS_DEFAULT_REGION="${params.AWS_DEFAULT_REGION}"
-                                    export DURATION_IN_SECONDS="${params.DURATION_IN_SECONDS}"
-                                    export FORCE_TURN="${params.FORCE_TURN}"
-                                    
-                                    ./canary/webrtc-c/scripts/setup-storage-viewer.sh
-                                """
-                            } catch (FlowInterruptedException err) {
-                                echo 'Aborted due to cancellation'
-                                throw err
-                            } catch (err) {
-                                HAS_ERROR = true
-                                unstable err.toString()
-                            }
+                        script {
+                            runViewerSessions("Viewer2", 55, "2")
                         }
                     }
+                }
+            }
+        }
+
+        stage('Three Viewers with Continuous Master') {
+            when {
+                equals expected: true, actual: params.JS_STORAGE_THREE_VIEWERS
+            }
+            parallel {
+                stage('Continuous StorageMaster') {
+                    agent {
+                        label params.MASTER_NODE_LABEL
+                    }
+                    steps {
+                        script {
+                            def mutableParams = [:] + params
+                            mutableParams.DURATION_IN_SECONDS = "1380"
+                            buildStorageCanary(false, mutableParams)
+                        }
+                    }
+                }
+                stage('StorageViewer1') {
+                    agent {
+                        label params.STORAGE_VIEWER_ONE_NODE_LABEL
+                    }
+                    steps {
+                        script {
+                            runViewerSessions("Viewer1", 55, "3")
+                        }
+                    }
+                }
+                stage('StorageViewer2') {
+                    agent {
+                        label params.STORAGE_VIEWER_TWO_NODE_LABEL
+                    }
+                    steps {
+                        script {
+                            runViewerSessions("Viewer2", 55, "3")
+                        }
+                    }
+                }
+                stage('StorageViewer3') {
+                    agent {
+                        label params.STORAGE_VIEWER_THREE_NODE_LABEL
+                    }
+                    steps {
+                        script {
+                            runViewerSessions("Viewer3", 55, "3")
+                        }
+                    }
+                }
+            }
+        }
+
+        stage('Stop Continuous StorageMaster') {
+            when {
+                anyOf {
+                    equals expected: true, actual: params.JS_STORAGE_VIEWER_JOIN
+                    equals expected: true, actual: params.JS_STORAGE_TWO_VIEWERS
+                    equals expected: true, actual: params.JS_STORAGE_THREE_VIEWERS
+                }
+            }
+            agent {
+                label params.MASTER_NODE_LABEL
+            }
+            steps {
+                script {
+                    sh """
+                        # Stop the background master process
+                        if [ -f master.pid ]; then
+                            kill \$(cat master.pid) || true
+                            rm -f master.pid
+                        fi
+                    """
                 }
             }
         }
@@ -595,6 +702,11 @@ pipeline {
                       string(name: 'MASTER_NODE_LABEL', value: params.MASTER_NODE_LABEL),
                       string(name: 'CONSUMER_NODE_LABEL', value: params.CONSUMER_NODE_LABEL),
                       string(name: 'VIEWER_NODE_LABEL', value: params.VIEWER_NODE_LABEL),
+                      string(name: 'STORAGE_VIEWER_NODE_LABEL', value: params.STORAGE_VIEWER_NODE_LABEL),
+                      string(name: 'STORAGE_VIEWER_ONE_NODE_LABEL', value: params.STORAGE_VIEWER_ONE_NODE_LABEL),
+                      string(name: 'STORAGE_VIEWER_TWO_NODE_LABEL', value: params.STORAGE_VIEWER_TWO_NODE_LABEL),
+                      string(name: 'STORAGE_VIEWER_THREE_NODE_LABEL', value: params.STORAGE_VIEWER_THREE_NODE_LABEL),
+                      string(name: 'VIEWER_COUNT', value: params.VIEWER_COUNT),
                       string(name: 'RUNNER_LABEL', value: params.RUNNER_LABEL),
                       string(name: 'SCENARIO_LABEL', value: params.SCENARIO_LABEL),
                       string(name: 'DURATION_IN_SECONDS', value: params.DURATION_IN_SECONDS),
@@ -606,6 +718,17 @@ pipeline {
                     ],
                     wait: false
                 )
+            }
+        }
+    }
+    
+    post {
+        always {
+            script {
+                sh """
+                    echo "Post-build cleanup - removing current workspace @tmp directory"
+                    rm -rf ${env.WORKSPACE}@tmp 2>/dev/null || true
+                """
             }
         }
     }

--- a/canary/webrtc-c/scripts/chrome-headless.js
+++ b/canary/webrtc-c/scripts/chrome-headless.js
@@ -11,7 +11,10 @@ function log(message) {
 class ViewerCanaryTest {
   constructor(config) {
     this.config = config;
-    log(`Initializing test with single viewer`);
+    this.viewerId = process.env.VIEWER_ID || 'Viewer1';
+    this.clientId = process.env.CLIENT_ID || `viewer-${Date.now()}`;
+    
+    log(`Initializing test with ${this.viewerId} (${this.clientId})`);
     
     this.sessionStartTime = Date.now();
     this.storageSessionJoined = false;
@@ -19,6 +22,22 @@ class ViewerCanaryTest {
     this.framesReceived = false;
     this.testCompleted = false;
     this.timerStarted = false;
+    
+    // Comprehensive timing tracking for WebRTC connection stages
+    this.offerReceivedTime = null;
+    this.answerSentTime = null;
+    this.firstIceCandidateReceivedTime = null;
+    this.firstIceCandidateSentTime = null;
+    this.allIceCandidatesGeneratedTime = null;
+    this.peerConnectionEstablishedTime = null;
+    
+    // Flags to track first occurrences
+    this.hasReceivedFirstIceCandidate = false;
+    this.hasSentFirstIceCandidate = false;
+    
+    // WebRTC connection retry tracking (internal viewer retries)
+    this.webrtcRetryCount = 0;
+    this.hadWebRTCRetries = false;
     
     this.browser = null;
     this.page = null;
@@ -41,6 +60,123 @@ class ViewerCanaryTest {
       const text = msg.text();
       log(`PAGE: ${text}`);
       
+      // Track SDP offer received
+      if (text.includes('[VIEWER] Received SDP offer from remote')) {
+        this.offerReceivedTime = Date.now();
+        log('SDP offer received timestamp captured');
+      }
+      
+      // Track SDP answer sent and calculate offer-to-answer metric
+      if (text.includes('[VIEWER] Sending SDP answer to remote')) {
+        this.answerSentTime = Date.now();
+        log('SDP answer sent timestamp captured');
+        
+        // Calculate and publish the Offer Received to Answer Sent Time metric
+        if (this.offerReceivedTime && this.answerSentTime) {
+          const offerToAnswerTime = this.answerSentTime - this.offerReceivedTime;
+          log(`Offer to Answer time: ${offerToAnswerTime}ms`);
+          
+          await CloudWatchMetrics.publishMsMetric(
+            `OfferReceivedToAnswerSentTime_${this.viewerId}`,
+            this.config.channelName,
+            offerToAnswerTime
+          );
+        }
+      }
+      
+      // Track first ICE candidate received from remote
+      if (text.includes('[VIEWER] Received ICE candidate from remote') && !this.hasReceivedFirstIceCandidate) {
+        this.firstIceCandidateReceivedTime = Date.now();
+        this.hasReceivedFirstIceCandidate = true;
+        log('First ICE candidate received timestamp captured');
+        
+        // Calculate answer-to-first-ice-received metric
+        if (this.answerSentTime && this.firstIceCandidateReceivedTime) {
+          const answerToFirstIceTime = this.firstIceCandidateReceivedTime - this.answerSentTime;
+          log(`Answer Sent to First ICE Received time: ${answerToFirstIceTime}ms`);
+          
+          await CloudWatchMetrics.publishMsMetric(
+            `AnswerSentToFirstIceReceivedTime_${this.viewerId}`,
+            this.config.channelName,
+            answerToFirstIceTime
+          );
+        }
+      }
+      
+      // Track first ICE candidate sent to remote
+      if (text.includes('[VIEWER] Sending ICE candidate to remote') && !this.hasSentFirstIceCandidate) {
+        this.firstIceCandidateSentTime = Date.now();
+        this.hasSentFirstIceCandidate = true;
+        log('First ICE candidate sent timestamp captured');
+        
+        // Calculate first-ice-received-to-first-ice-sent metric
+        if (this.firstIceCandidateReceivedTime && this.firstIceCandidateSentTime) {
+          const firstIceReceivedToSentTime = this.firstIceCandidateSentTime - this.firstIceCandidateReceivedTime;
+          log(`First ICE Received to First ICE Sent time: ${firstIceReceivedToSentTime}ms`);
+          
+          await CloudWatchMetrics.publishMsMetric(
+            `FirstIceReceivedToFirstIceSentTime_${this.viewerId}`,
+            this.config.channelName,
+            firstIceReceivedToSentTime
+          );
+        }
+      }
+      
+      // Track when all ICE candidates are generated
+      if (text.includes('[VIEWER] All ICE candidates have been generated for remote')) {
+        this.allIceCandidatesGeneratedTime = Date.now();
+        log('All ICE candidates generated timestamp captured');
+        
+        // Calculate first-ice-sent-to-all-ice-generated metric
+        if (this.firstIceCandidateSentTime && this.allIceCandidatesGeneratedTime) {
+          const firstIceSentToAllGeneratedTime = this.allIceCandidatesGeneratedTime - this.firstIceCandidateSentTime;
+          log(`First ICE Sent to All ICE Generated time: ${firstIceSentToAllGeneratedTime}ms`);
+          
+          await CloudWatchMetrics.publishMsMetric(
+            `FirstIceSentToAllIceGeneratedTime_${this.viewerId}`,
+            this.config.channelName,
+            firstIceSentToAllGeneratedTime
+          );
+        }
+      }
+      
+      // Track peer connection establishment
+      if (text.includes('[VIEWER] Connection to peer successful!')) {
+        this.peerConnectionEstablishedTime = Date.now();
+        log('Peer connection established timestamp captured');
+        
+        // Calculate all-ice-generated-to-connection-established metric
+        if (this.allIceCandidatesGeneratedTime && this.peerConnectionEstablishedTime) {
+          const allIceToConnectionTime = this.peerConnectionEstablishedTime - this.allIceCandidatesGeneratedTime;
+          log(`All ICE Generated to Connection Established time: ${allIceToConnectionTime}ms`);
+          
+          await CloudWatchMetrics.publishMsMetric(
+            `AllIceGeneratedToConnectionEstablishedTime_${this.viewerId}`,
+            this.config.channelName,
+            allIceToConnectionTime
+          );
+        }
+        
+        // Calculate total connection establishment time (offer to peer connection)
+        if (this.offerReceivedTime && this.peerConnectionEstablishedTime) {
+          const totalConnectionTime = this.peerConnectionEstablishedTime - this.offerReceivedTime;
+          log(`Total Connection Establishment time (Offer to Peer Connection): ${totalConnectionTime}ms`);
+          
+          await CloudWatchMetrics.publishMsMetric(
+            `TotalConnectionEstablishmentTime_${this.viewerId}`,
+            this.config.channelName,
+            totalConnectionTime
+          );
+        }
+      }
+      
+      // Track WebRTC connection retries
+      if (text.includes('[ERROR] [VIEWER] Connection failed after 30 seconds, will enter retry.')) {
+        this.webrtcRetryCount++;
+        this.hadWebRTCRetries = true;
+        log(`WebRTC connection retry detected! Total retries: ${this.webrtcRetryCount}`);
+      }
+      
       if (text.includes('Successfully joined the storage session')) {
         log('Storage session joined - ready to monitor frames!');
         this.storageSessionJoined = true;
@@ -53,7 +189,7 @@ class ViewerCanaryTest {
         
         const joinTime = Date.now() - this.sessionStartTime;
         await CloudWatchMetrics.publishMsMetric(
-          'JoinSSAsViewerTime',
+          `JoinSSAsViewerTime_${this.viewerId}`,
           this.config.channelName,
           joinTime
         );
@@ -76,6 +212,7 @@ class ViewerCanaryTest {
       sessionToken: process.env.AWS_SESSION_TOKEN || '',
       sendVideo: this.config.sendVideo || 'false',
       sendAudio: this.config.sendAudio || 'false',
+      useTrickleICE: 'true',
     });
     
     // Add forceTURN parameter if configured
@@ -84,11 +221,6 @@ class ViewerCanaryTest {
     }
     
     return `https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-js/examples/index.html?${params}`;
-  }
-
-  async waitForChannel() {
-    log('Waiting 2 minutes for master to create channel...');
-    await new Promise(resolve => setTimeout(resolve, 120000));
   }
 
   async initializePage(page) {
@@ -106,42 +238,32 @@ class ViewerCanaryTest {
 
   async waitForViewerStart(page) {
     log('Waiting for viewer to start...');
-    const maxRetries = 3;
+    const startTimeout = 60000;
+    const startTime = Date.now();
     
-    for (let retry = 0; retry < maxRetries; retry++) {
-      if (retry > 0) {
-        log(`Retry ${retry}: Restarting viewer...`);
-        await page.click('#viewer-button');
+    while ((Date.now() - startTime) < startTimeout) {
+      const status = await page.evaluate(() => ({
+        viewerExists: !!(window.viewer),
+        connectionState: window.viewer?.pc?.iceConnectionState,
+        signalingState: window.viewer?.pc?.signalingState,
+        error: window.viewer?.error
+      }));
+      
+      if (status.viewerExists && !status.error) {
+        log('Viewer started successfully!');
+        log(`Connection state: ${status.connectionState}`);
+        log(`Signaling state: ${status.signalingState}`);
+        return true;
       }
       
-      const startTimeout = 60000;
-      const startTime = Date.now();
-      
-      while ((Date.now() - startTime) < startTimeout) {
-        const status = await page.evaluate(() => ({
-          viewerExists: !!(window.viewer),
-          connectionState: window.viewer?.pc?.iceConnectionState,
-          signalingState: window.viewer?.pc?.signalingState,
-          error: window.viewer?.error
-        }));
-        
-        if (status.viewerExists && !status.error) {
-          log('Viewer started successfully!');
-          log(`Connection state: ${status.connectionState}`);
-          log(`Signaling state: ${status.signalingState}`);
-          return true;
-        }
-        
-        if (status.error) {
-          log('Viewer error detected, will retry...');
-          break;
-        }
-        
-        await new Promise(resolve => setTimeout(resolve, 1000));
+      if (status.error) {
+        throw new Error(`Viewer error: ${status.error}`);
       }
+      
+      await new Promise(resolve => setTimeout(resolve, 1000));
     }
     
-    throw new Error('Viewer failed to start after 3 retries');
+    throw new Error('Viewer failed to start within 60 seconds');
   }
 
   async waitForStorageSession() {
@@ -235,7 +357,7 @@ class ViewerCanaryTest {
     
     const frameDetectionTime = Date.now() - this.sessionStartTime;
     await CloudWatchMetrics.publishMsMetric(
-      'TimeToFirstFrame',
+      `TimeToFirstFrame_${this.viewerId}`,
       this.config.channelName,
       frameDetectionTime
     );
@@ -245,6 +367,14 @@ class ViewerCanaryTest {
 
   async monitorConnection(page) {
     log('Storage session joined! Now monitoring connection state...');
+    
+    // Start timer immediately since we already joined the storage session
+    this.timerStarted = true;
+    log('Storage session joined, running test for 45 seconds...');
+    setTimeout(() => {
+      this.testCompleted = true;
+    }, 45000);
+    
     let lastStatusLog = 0;
     const statusLogInterval = 10000;
     
@@ -253,16 +383,6 @@ class ViewerCanaryTest {
       
       if (frameStats.hasActiveVideo && !this.framesReceived) {
         await this.handleVideoDetection(page);
-      }
-      
-      if (frameStats.storageSessionActive && !this.timerStarted) {
-        log('Storage session active!');
-        this.timerStarted = true;
-        
-        log(`Storage session active, running test for 20 seconds...`);
-        setTimeout(() => {
-          this.testCompleted = true;
-        }, 20000);
       }
       
       if (!frameStats.viewerExists) {
@@ -282,7 +402,7 @@ class ViewerCanaryTest {
     }
   }
 
-  getTestResults() {
+  async getTestResults() {
     const metrics = {
       success: this.storageSessionJoined,
       storageSessionJoined: this.storageSessionJoined,
@@ -294,10 +414,28 @@ class ViewerCanaryTest {
     log('Test completed!');
     log(`Final metrics: ${JSON.stringify(metrics)}`);
     
-    const success = metrics.success && this.framesReceived;
-    log(success ? 'TEST PASSED: Frames received successfully' : 'TEST FAILED: No frames received');
+    // Publish success rate metric (100% for success, 0% for failure)
+    const successRate = this.storageSessionJoined ? 100 : 0;
+    await CloudWatchMetrics.publishPercentageMetric(
+      `StorageSessionSuccessRate_${this.viewerId}`,
+      this.config.channelName,
+      successRate
+    );
     
-    return { ...metrics, success, framesReceived: this.framesReceived };
+    // Publish WebRTC connection retry count metric
+    await CloudWatchMetrics.publishCountMetric(
+      `WebRTCConnectionRetryCount_${this.viewerId}`,
+      this.config.channelName,
+      this.webrtcRetryCount
+    );
+    
+    log(`WebRTC Connection Retry Summary: Total retries: ${this.webrtcRetryCount}, Had retries: ${this.hadWebRTCRetries}`);
+    
+    // Success is based on storage session joining, not frame reception
+    const success = this.storageSessionJoined;
+    log(success ? 'TEST PASSED: Storage session joined successfully' : 'TEST FAILED: Storage session not joined');
+    
+    return { ...metrics, success };
   }
 }
 
@@ -410,7 +548,6 @@ async function runViewerCanary(config) {
       (async () => {
         await test.initializeCloudWatch();
         test.validateEnvironment();
-        // await test.waitForChannel();
         
         // Create and initialize single browser and page
         log(`Creating viewer instance...`);
@@ -431,7 +568,7 @@ async function runViewerCanary(config) {
         await test.monitorConnection(test.page);
         
         cleanupCompleted = true; // Mark cleanup as not needed (normal completion)
-        return test.getTestResults();
+        return await test.getTestResults();
       })(),
       cleanupPromise,
       hardTimeoutPromise

--- a/canary/webrtc-c/scripts/cloudwatch.js
+++ b/canary/webrtc-c/scripts/cloudwatch.js
@@ -12,12 +12,30 @@ class CloudWatchMetrics {
             return msValue;
         }
 
+        const dimensions = [{
+            Name: 'StorageWithViewerChannelName',
+            Value: channelName,
+        }];
+        
+        // Add JobName dimension if available
+        if (process.env.JOB_NAME) {
+            dimensions.push({
+                Name: 'JobName',
+                Value: process.env.JOB_NAME
+            });
+        }
+        
+        // Add RunnerLabel dimension if available
+        if (process.env.RUNNER_LABEL) {
+            dimensions.push({
+                Name: 'RunnerLabel',
+                Value: process.env.RUNNER_LABEL
+            });
+        }
+
         const msMetric = {
             MetricName: metricName,
-            Dimensions: [{
-                Name: 'StorageWithViewerChannelName',
-                Value: channelName,
-            }],
+            Dimensions: dimensions,
             Timestamp: new Date(when),
             Value: msValue,
             Unit: 'Milliseconds'
@@ -36,6 +54,104 @@ class CloudWatchMetrics {
             console.error(e);
         }
         return msValue;
+    }
+    
+    static async publishPercentageMetric(metricName, channelName, percentageValue, when = Date.now()) {
+        if (!this.cwClient || !channelName) {
+            return percentageValue;
+        }
+
+        const dimensions = [{
+            Name: 'StorageWithViewerChannelName',
+            Value: channelName,
+        }];
+        
+        // Add JobName dimension if available
+        if (process.env.JOB_NAME) {
+            dimensions.push({
+                Name: 'JobName',
+                Value: process.env.JOB_NAME
+            });
+        }
+        
+        // Add RunnerLabel dimension if available
+        if (process.env.RUNNER_LABEL) {
+            dimensions.push({
+                Name: 'RunnerLabel',
+                Value: process.env.RUNNER_LABEL
+            });
+        }
+
+        const percentageMetric = {
+            MetricName: metricName,
+            Dimensions: dimensions,
+            Timestamp: new Date(when),
+            Value: percentageValue,
+            Unit: 'Percent'
+        };
+
+        const commandInput = {
+            Namespace: 'ViewerApplication',
+            MetricData: [percentageMetric],
+        };
+
+        const command = new PutMetricDataCommand(commandInput);
+        try {
+            await this.cwClient.send(command);
+            console.log(metricName, 'percentage sent to cloudwatch!');
+        } catch (e) {
+            console.error(e);
+        }
+        return percentageValue;
+    }
+    
+    static async publishCountMetric(metricName, channelName, countValue, when = Date.now()) {
+        if (!this.cwClient || !channelName) {
+            return countValue;
+        }
+
+        const dimensions = [{
+            Name: 'StorageWithViewerChannelName',
+            Value: channelName,
+        }];
+        
+        // Add JobName dimension if available
+        if (process.env.JOB_NAME) {
+            dimensions.push({
+                Name: 'JobName',
+                Value: process.env.JOB_NAME
+            });
+        }
+        
+        // Add RunnerLabel dimension if available
+        if (process.env.RUNNER_LABEL) {
+            dimensions.push({
+                Name: 'RunnerLabel',
+                Value: process.env.RUNNER_LABEL
+            });
+        }
+
+        const countMetric = {
+            MetricName: metricName,
+            Dimensions: dimensions,
+            Timestamp: new Date(when),
+            Value: countValue,
+            Unit: 'Count'
+        };
+
+        const commandInput = {
+            Namespace: 'ViewerApplication',
+            MetricData: [countMetric],
+        };
+
+        const command = new PutMetricDataCommand(commandInput);
+        try {
+            await this.cwClient.send(command);
+            console.log(metricName, 'count sent to cloudwatch!');
+        } catch (e) {
+            console.error(e);
+        }
+        return countValue;
     }
 }
 

--- a/canary/webrtc-c/scripts/setup-storage-viewer.sh
+++ b/canary/webrtc-c/scripts/setup-storage-viewer.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
-
-# Wait for StorageMaster to start up
-echo "Waiting 1 minute for StorageMaster to start..."
-sleep 60
-
 # Install Node.js if not present with retry logic
 if ! command -v npm &> /dev/null; then
     echo "Node.js not found, installing..."
+    
+    # Remove conflicting packages first
+    sudo apt-get remove -y libnode72 nodejs 2>/dev/null || true
+    sudo apt-get autoremove -y 2>/dev/null || true
+    
     for i in {1..3}; do
         if curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash - && sudo apt-get install -y nodejs; then
             break
@@ -19,6 +19,13 @@ if ! command -v npm &> /dev/null; then
 else
     echo "Node.js already installed: $(node --version)"
 fi
+
+# Verify npm is available after installation
+if ! command -v npm &> /dev/null; then
+    echo "ERROR: npm command not found after installation. Node.js installation failed."
+    exit 1
+fi
+echo "npm verified: $(npm --version)"
 
 cd ./canary/webrtc-c/scripts || { echo "ERROR: Failed to change directory to ./canary/webrtc-c/scripts"; exit 1; }
 


### PR DESCRIPTION
Add StorageTwoViewers and StorageThreeViewers tests — C Master streams to storage with 2-3 JS Viewers joining in parallel on separate nodes.

Tests Added:
- StorageTwoViewers: 2 JS Viewers with 15s stagger
- StorageThreeViewers: 3 JS Viewers with 15s stagger

Features:
- 3-cycle viewer sessions (3 join/leave cycles per run)
- Per-viewer metric isolation (viewer ID suffix)
- Reusable runViewerSessions() function
- Master-ready signal polling (MASTER_READY flag, 5s poll, 20 min timeout)
- Isolated viewer workspaces (fixes git pack corruption)
- Conditional workspace cleanup
- Jenkins timeout on kvsWebrtcStorageSample
- Peer connection phase breakdown metrics (8 timing metrics)
- useTrickleICE enabled
- Frequency reduced to 1 hour per run

Metrics Introduced:
- OfferReceivedToAnswerSentTime, AnswerSentToFirstIceReceivedTime
- FirstIceReceivedToFirstIceSentTime, FirstIceSentToAllIceGeneratedTime
- AllIceGeneratedToConnectionEstablishedTime
- TotalConnectionEstablishmentTime, TimeToFirstFrame
- StorageSessionSuccessRate, WebRTCConnectionRetryCount
- ViewerJoinPercentage

Date: Jan 7 - Feb 18, 2026


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
