### PR TITLE
Merge `alive-metric` into `reschedule-logic`

### DIFF
--- a/canary/webrtc-c/jobs/storage_runner.groovy
+++ b/canary/webrtc-c/jobs/storage_runner.groovy
@@ -787,9 +787,11 @@ pipeline {
             }
         }
 
-        stage('Unset credentials') {
+        stage('Cleanup') {
             steps {
                 script {
+                    sh "rm -f '${env.WORKSPACE}/.in_use'"
+                    pushKeepAlive('CleanupComplete')
                     env.AWS_ACCESS_KEY_ID = ''
                     env.AWS_SECRET_ACCESS_KEY = ''
                     env.AWS_SESSION_TOKEN = ''
@@ -803,11 +805,6 @@ pipeline {
         always {
             script {
                 sh "rm -f '${env.WORKSPACE}/.in_use'"
-                try {
-                    pushKeepAlive('CleanupComplete')
-                } catch (err) {
-                    echo "CleanupComplete keep-alive failed (credentials may be unset): ${err.getMessage()}"
-                }
 
                 echo "=========================================="
                 echo "Storage Runner Summary"

--- a/canary/webrtc-c/jobs/storage_runner.groovy
+++ b/canary/webrtc-c/jobs/storage_runner.groovy
@@ -18,6 +18,20 @@ HAS_ERROR = false
 IS_ABORTED = false
 VIEWER_SESSION_RESULTS = [:]
 
+def pushKeepAlive(stageName) {
+    def region = params.AWS_DEFAULT_REGION ?: 'us-west-2'
+    def scenarioLabel = params.SCENARIO_LABEL ?: 'StoragePeriodic'
+    def runnerLabel = params.RUNNER_LABEL ?: 'StoragePeriodic'
+    sh """
+        aws cloudwatch put-metric-data \
+            --namespace KinesisVideoSDKCanary \
+            --region ${region} \
+            --metric-data \
+                'MetricName=PipelineKeepAlive,Value=1.0,Unit=None,Dimensions=[{Name=Stage,Value=${stageName}},{Name=StorageWebRTCSDKCanaryLabel,Value=${scenarioLabel}},{Name=RunnerLabel,Value=${runnerLabel}}]'
+    """
+    echo "KeepAlive: ${stageName}"
+}
+
 // Signal flag: set to true when the storage master build is complete and the binary
 // is about to start streaming. Viewers poll this instead of sleeping a fixed duration.
 MASTER_READY = false
@@ -46,6 +60,8 @@ def buildWebRTCProject(thing_prefix) {
         fi
         cd '${repoDir}' && git fetch origin '+refs/heads/*:refs/remotes/origin/*' && git checkout -f '${params.GIT_HASH}'
         flock -u 9"""
+
+    pushKeepAlive('GitCheckoutComplete')
 
     // Sync cleanup cron script if it changed
     sh """
@@ -159,6 +175,7 @@ def runViewerSessions(viewerId = "", waitMinutes = 2, viewerCount = "1") {
                 export JS_PAGE_URL="${params.JS_BRANCH ?: 'master'}"
                 ./canary/webrtc-c/scripts/prepare-storage-viewer.sh
             """
+            pushKeepAlive('ViewerPrepareComplete')
 
             if (waitMinutes > 0) {
                 echo "Waiting for master to be ready (timeout: ${waitMinutes} minutes)..."
@@ -228,6 +245,7 @@ def runViewerSessions(viewerId = "", waitMinutes = 2, viewerCount = "1") {
                 unstable err.toString()
             }
 
+            pushKeepAlive('ViewerSessionComplete')
             echo "${viewerId ? viewerId + ' ' : ''}viewer session completed"
         } finally {
             sh "rm -f '${env.WORKSPACE}/.in_use'"
@@ -337,6 +355,7 @@ def buildStorageCanary(isConsumer, params) {
         MASTER_READY = true
         echo "Master build complete, signaling viewers (MASTER_READY=true)"
         def buildDir = "${env.HOME}/webrtc-c-storage-master/build"
+        pushKeepAlive('MasterStarted')
         withRunnerWrapper(envs) {
             // Timeout: duration + 5 min buffer. The C binary should exit on its own
             // after CANARY_DURATION_IN_SECONDS, but if it hangs (e.g., ICE agent
@@ -347,6 +366,7 @@ def buildStorageCanary(isConsumer, params) {
                     ./kvsWebrtcStorageSample"""
             }
         }
+        pushKeepAlive('MasterFinished')
     } else {
         def envs = (commonEnvs + consumerEnvs).collect{ k, v -> "${k}=${v}" }
         withRunnerWrapper(envs) {
@@ -774,6 +794,11 @@ pipeline {
         always {
             script {
                 sh "rm -f '${env.WORKSPACE}/.in_use'"
+                try {
+                    pushKeepAlive('CleanupComplete')
+                } catch (err) {
+                    echo "CleanupComplete keep-alive failed (credentials may be unset): ${err.getMessage()}"
+                }
 
                 echo "=========================================="
                 echo "Storage Runner Summary"

--- a/canary/webrtc-c/jobs/storage_runner.groovy
+++ b/canary/webrtc-c/jobs/storage_runner.groovy
@@ -23,6 +23,7 @@ def pushKeepAlive(stageName) {
     def scenarioLabel = params.SCENARIO_LABEL ?: 'StoragePeriodic'
     def runnerLabel = params.RUNNER_LABEL ?: 'StoragePeriodic'
     sh """
+        export PATH="/usr/local/bin:/usr/bin:\$PATH"
         aws cloudwatch put-metric-data \
             --namespace KinesisVideoSDKCanary \
             --region ${region} \

--- a/canary/webrtc-c/jobs/storage_runner.groovy
+++ b/canary/webrtc-c/jobs/storage_runner.groovy
@@ -22,15 +22,19 @@ def pushKeepAlive(stageName) {
     def region = params.AWS_DEFAULT_REGION ?: 'us-west-2'
     def scenarioLabel = params.SCENARIO_LABEL ?: 'StoragePeriodic'
     def runnerLabel = params.RUNNER_LABEL ?: 'StoragePeriodic'
-    sh """
+    def rc = sh(script: """
         export PATH="/usr/local/bin:/usr/bin:\$PATH"
         aws cloudwatch put-metric-data \
             --namespace KinesisVideoSDKCanary \
             --region ${region} \
             --metric-data \
                 'MetricName=PipelineKeepAlive,Value=1.0,Unit=None,Dimensions=[{Name=Stage,Value=${stageName}},{Name=StorageWebRTCSDKCanaryLabel,Value=${scenarioLabel}},{Name=RunnerLabel,Value=${runnerLabel}}]'
-    """
-    echo "KeepAlive: ${stageName}"
+    """, returnStatus: true)
+    if (rc == 0) {
+        echo "KeepAlive: ${stageName}"
+    } else {
+        echo "KeepAlive: ${stageName} (emit failed, rc=${rc} — aws CLI may not be installed on this node)"
+    }
 }
 
 // Signal flag: set to true when the storage master build is complete and the binary

--- a/canary/webrtc-c/jobs/storage_runner.groovy
+++ b/canary/webrtc-c/jobs/storage_runner.groovy
@@ -445,6 +445,10 @@ pipeline {
         label params.MASTER_NODE_LABEL
     }
 
+    options {
+        skipDefaultCheckout()
+    }
+
     parameters {
         string(name: 'AWS_KVS_LOG_LEVEL', defaultValue: '2')
         string(name: 'LOG_GROUP_NAME', defaultValue: 'WebrtcSDK')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
_What is changed_

- Added a `PipelineKeepAlive` CloudWatch metric emitted at key pipeline stages (GitCheckoutComplete, ViewerPrepareComplete, ViewerSessionComplete, MasterStarted, MasterFinished, CleanupComplete)
- Added `skipDefaultCheckout()` pipeline option
- Renamed the `Unset credentials` stage to `Cleanup` and added workspace `.in_use` file removal before credential unset
- Made the `pushKeepAlive` helper non-fatal — it logs a warning and continues if the `aws` CLI is unavailable on viewer nodes

_Why it's changed_

- **Keep-alive metric**: Long-running storage canary pipelines can appear hung from the outside. A heartbeat metric at each stage provides visibility into pipeline progress and helps distinguish "still running" from "actually stuck" without inspecting Jenkins logs.
- **skipDefaultCheckout**: Stale `.git` workspace state was causing checkout failures on reused Jenkins nodes. Skipping the default checkout avoids this since the pipeline already does an explicit `git fetch + checkout` to the exact commit hash.
- **Non-fatal pushKeepAlive**: Viewer nodes may not have the `aws` CLI installed (they run JS viewers via the prepare/run scripts). The metric is observability-only and must not fail the pipeline.
- **Cleanup stage rename + .in_use removal**: Ensures the node-lock file is cleaned up even if the viewer/master stages errored, and the stage name now reflects its broader purpose.

_How it's changed_

- **`storage_runner.groovy`** (sole file modified):
  - New `pushKeepAlive(stageName)` function that calls `aws cloudwatch put-metric-data` with namespace `KinesisVideoSDKCanary`, dimensions `Stage`, `StorageWebRTCSDKCanaryLabel`, and `RunnerLabel`. Uses `returnStatus: true` so a non-zero exit doesn't abort the build.
  - `pushKeepAlive` calls inserted after: git checkout, viewer prepare, viewer session end, master binary start, master binary exit, and cleanup.
  - Added `options { skipDefaultCheckout() }` block to the pipeline definition.
  - `stage('Unset credentials')` → `stage('Cleanup')` with an added `rm -f .in_use` and keep-alive emit before unsetting credentials.
  - PATH is explicitly set in the `aws` call (`/usr/local/bin:/usr/bin`) to handle nodes where `aws` isn't on the default Jenkins PATH.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
