### PR TITLE
Phase 3: Gamma Expansion

### DIFF
--- a/canary/webrtc-c/jobs/gamma_orchestrator.groovy
+++ b/canary/webrtc-c/jobs/gamma_orchestrator.groovy
@@ -1,0 +1,268 @@
+/**
+ * Gamma Test Orchestrator
+ * 
+ * This orchestrator runs WebRTC storage viewer tests against a custom endpoint (e.g., gamma).
+ * It uses the dedicated webrtc-gamma-runner job, which is independent from production runners.
+ * 
+ * Tests available:
+ *   - StorageWithViewer (1 viewer)
+ *   - StorageTwoViewers (2 viewers)  
+ *   - StorageThreeViewers (3 viewers)
+ * 
+ * Usage:
+ *   1. Click "Build with Parameters"
+ *   2. Enter the gamma endpoint URL in the ENDPOINT field
+ *   3. Select which tests to run
+ *   4. Click "Build"
+ */
+
+GIT_URL = 'https://github.com/aws-samples/amazon-kinesis-video-streams-demos.git'
+GIT_HASH = 'master'
+
+// Dedicated gamma runner job name
+GAMMA_RUNNER_JOB = "webrtc-gamma-runner"
+
+// Test duration for gamma tests (shorter than production for faster feedback)
+TEST_DURATION_IN_SECONDS = 600 // 10 min
+
+pipeline {
+    agent {
+        label 'profiling'
+    }
+
+    parameters {
+        string(
+            name: 'ENDPOINT',
+            defaultValue: '',
+            description: 'Custom endpoint URL (e.g., gamma endpoint). This is REQUIRED.'
+        )
+        string(
+            name: 'AWS_DEFAULT_REGION',
+            defaultValue: 'us-west-2',
+            description: 'AWS region for the tests'
+        )
+        string(
+            name: 'VIEWER_WAIT_MINUTES',
+            defaultValue: '2',
+            description: 'Minutes to wait for master to build before starting viewers (0 = no wait)'
+        )
+        string(
+            name: 'VIEWER_SESSION_DURATION_SECONDS',
+            defaultValue: '600',
+            description: 'Duration in seconds for each viewer session (default 10 minutes)'
+        )
+        booleanParam(
+            name: 'RUN_STORAGE_WITH_VIEWER',
+            defaultValue: true,
+            description: 'Run StorageWithViewer test (1 viewer)'
+        )
+        booleanParam(
+            name: 'RUN_STORAGE_TWO_VIEWERS',
+            defaultValue: false,
+            description: 'Run StorageTwoViewers test (2 viewers)'
+        )
+        booleanParam(
+            name: 'RUN_STORAGE_THREE_VIEWERS',
+            defaultValue: false,
+            description: 'Run StorageThreeViewers test (3 viewers)'
+        )
+        string(
+            name: 'GIT_HASH',
+            defaultValue: GIT_HASH,
+            description: 'Git branch/tag/commit to use'
+        )
+        booleanParam(
+            name: 'RESCHEDULE',
+            defaultValue: false,
+            description: 'Enable continuous testing (reschedule after each run completes)'
+        )
+    }
+
+    options {
+        buildDiscarder(logRotator(numToKeepStr: '30'))
+        timestamps()
+    }
+
+    stages {
+        stage('Validate Parameters') {
+            steps {
+                script {
+                    if (!params.ENDPOINT?.trim()) {
+                        error "ENDPOINT parameter is required. Please provide the gamma endpoint URL."
+                    }
+                    
+                    if (!params.RUN_STORAGE_WITH_VIEWER && !params.RUN_STORAGE_TWO_VIEWERS && !params.RUN_STORAGE_THREE_VIEWERS) {
+                        error "At least one test must be selected to run."
+                    }
+                    
+                    echo "=========================================="
+                    echo "Gamma Test Configuration"
+                    echo "=========================================="
+                    echo "Endpoint: ${params.ENDPOINT}"
+                    echo "Region: ${params.AWS_DEFAULT_REGION}"
+                    echo "Viewer Wait: ${params.VIEWER_WAIT_MINUTES} minutes"
+                    echo "Git Hash: ${params.GIT_HASH}"
+                    echo "Tests to run:"
+                    if (params.RUN_STORAGE_WITH_VIEWER) echo "  - StorageWithViewer (1 viewer)"
+                    if (params.RUN_STORAGE_TWO_VIEWERS) echo "  - StorageTwoViewers (2 viewers)"
+                    if (params.RUN_STORAGE_THREE_VIEWERS) echo "  - StorageThreeViewers (3 viewers)"
+                    echo "=========================================="
+                }
+            }
+        }
+
+        stage('Checkout') {
+            steps {
+                checkout([$class: 'GitSCM', branches: [[name: params.GIT_HASH]],
+                          userRemoteConfigs: [[url: GIT_URL]]])
+                
+                script {
+                    env.CURRENT_GIT_HASH = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
+                    echo "Using git hash: ${env.CURRENT_GIT_HASH}"
+                }
+            }
+        }
+
+        stage('Run Gamma Tests') {
+            parallel {
+                stage('StorageWithViewer') {
+                    when {
+                        expression { return params.RUN_STORAGE_WITH_VIEWER }
+                    }
+                    steps {
+                        script {
+                            echo "Starting StorageWithViewer test..."
+                            def result = build(
+                                job: GAMMA_RUNNER_JOB,
+                                parameters: [
+                                    string(name: 'AWS_KVS_LOG_LEVEL', value: "2"),
+                                    string(name: 'GIT_URL', value: GIT_URL),
+                                    string(name: 'GIT_HASH', value: env.CURRENT_GIT_HASH),
+                                    string(name: 'LOG_GROUP_NAME', value: "WebrtcSDK"),
+                                    booleanParam(name: 'DEBUG_LOG_SDP', value: true),
+                                    booleanParam(name: 'JS_STORAGE_VIEWER_JOIN', value: true),
+                                    booleanParam(name: 'JS_STORAGE_TWO_VIEWERS', value: false),
+                                    booleanParam(name: 'JS_STORAGE_THREE_VIEWERS', value: false),
+                                    string(name: 'DURATION_IN_SECONDS', value: TEST_DURATION_IN_SECONDS.toString()),
+                                    string(name: 'MASTER_NODE_LABEL', value: "webrtc-storage-master"),
+                                    string(name: 'STORAGE_VIEWER_NODE_LABEL', value: "webrtc-storage-viewer"),
+                                    string(name: 'RUNNER_LABEL', value: "GammaStorageWithViewer"),
+                                    string(name: 'SCENARIO_LABEL', value: "GammaStorageWithViewer"),
+                                    string(name: 'AWS_DEFAULT_REGION', value: params.AWS_DEFAULT_REGION),
+                                    string(name: 'ENDPOINT', value: params.ENDPOINT),
+                                    string(name: 'METRIC_SUFFIX', value: "-gamma"),
+                                    string(name: 'VIEWER_WAIT_MINUTES', value: params.VIEWER_WAIT_MINUTES),
+                                    string(name: 'VIEWER_SESSION_DURATION_SECONDS', value: params.VIEWER_SESSION_DURATION_SECONDS),
+                                    booleanParam(name: 'FIRST_ITERATION', value: true),
+                                    booleanParam(name: 'RESCHEDULE', value: params.RESCHEDULE),
+                                ],
+                                wait: true,
+                                propagate: false
+                            )
+                            echo "StorageWithViewer result: ${result.result}"
+                        }
+                    }
+                }
+
+                stage('StorageTwoViewers') {
+                    when {
+                        expression { return params.RUN_STORAGE_TWO_VIEWERS }
+                    }
+                    steps {
+                        script {
+                            echo "Starting StorageTwoViewers test..."
+                            def result = build(
+                                job: GAMMA_RUNNER_JOB,
+                                parameters: [
+                                    string(name: 'AWS_KVS_LOG_LEVEL', value: "2"),
+                                    string(name: 'GIT_URL', value: GIT_URL),
+                                    string(name: 'GIT_HASH', value: env.CURRENT_GIT_HASH),
+                                    string(name: 'LOG_GROUP_NAME', value: "WebrtcSDK"),
+                                    booleanParam(name: 'DEBUG_LOG_SDP', value: true),
+                                    booleanParam(name: 'JS_STORAGE_VIEWER_JOIN', value: false),
+                                    booleanParam(name: 'JS_STORAGE_TWO_VIEWERS', value: true),
+                                    booleanParam(name: 'JS_STORAGE_THREE_VIEWERS', value: false),
+                                    string(name: 'DURATION_IN_SECONDS', value: TEST_DURATION_IN_SECONDS.toString()),
+                                    string(name: 'MASTER_NODE_LABEL', value: "webrtc-storage-master"),
+                                    string(name: 'STORAGE_VIEWER_ONE_NODE_LABEL', value: "webrtc-storage-multi-viewer-1"),
+                                    string(name: 'STORAGE_VIEWER_TWO_NODE_LABEL', value: "webrtc-storage-multi-viewer-2"),
+                                    string(name: 'RUNNER_LABEL', value: "GammaStorageTwoViewers"),
+                                    string(name: 'SCENARIO_LABEL', value: "GammaStorageTwoViewers"),
+                                    string(name: 'AWS_DEFAULT_REGION', value: params.AWS_DEFAULT_REGION),
+                                    string(name: 'ENDPOINT', value: params.ENDPOINT),
+                                    string(name: 'METRIC_SUFFIX', value: "-gamma"),
+                                    string(name: 'VIEWER_WAIT_MINUTES', value: params.VIEWER_WAIT_MINUTES),
+                                    string(name: 'VIEWER_SESSION_DURATION_SECONDS', value: params.VIEWER_SESSION_DURATION_SECONDS),
+                                    booleanParam(name: 'FIRST_ITERATION', value: true),
+                                    booleanParam(name: 'RESCHEDULE', value: params.RESCHEDULE),
+                                ],
+                                wait: true,
+                                propagate: false
+                            )
+                            echo "StorageTwoViewers result: ${result.result}"
+                        }
+                    }
+                }
+
+                stage('StorageThreeViewers') {
+                    when {
+                        expression { return params.RUN_STORAGE_THREE_VIEWERS }
+                    }
+                    steps {
+                        script {
+                            echo "Starting StorageThreeViewers test..."
+                            def result = build(
+                                job: GAMMA_RUNNER_JOB,
+                                parameters: [
+                                    string(name: 'AWS_KVS_LOG_LEVEL', value: "2"),
+                                    string(name: 'GIT_URL', value: GIT_URL),
+                                    string(name: 'GIT_HASH', value: env.CURRENT_GIT_HASH),
+                                    string(name: 'LOG_GROUP_NAME', value: "WebrtcSDK"),
+                                    booleanParam(name: 'DEBUG_LOG_SDP', value: true),
+                                    booleanParam(name: 'JS_STORAGE_VIEWER_JOIN', value: false),
+                                    booleanParam(name: 'JS_STORAGE_TWO_VIEWERS', value: false),
+                                    booleanParam(name: 'JS_STORAGE_THREE_VIEWERS', value: true),
+                                    string(name: 'DURATION_IN_SECONDS', value: TEST_DURATION_IN_SECONDS.toString()),
+                                    string(name: 'MASTER_NODE_LABEL', value: "webrtc-storage-master"),
+                                    string(name: 'STORAGE_VIEWER_ONE_NODE_LABEL', value: "webrtc-storage-multi-viewer-1"),
+                                    string(name: 'STORAGE_VIEWER_TWO_NODE_LABEL', value: "webrtc-storage-multi-viewer-2"),
+                                    string(name: 'STORAGE_VIEWER_THREE_NODE_LABEL', value: "webrtc-storage-consumer"),
+                                    string(name: 'RUNNER_LABEL', value: "GammaStorageThreeViewers"),
+                                    string(name: 'SCENARIO_LABEL', value: "GammaStorageThreeViewers"),
+                                    string(name: 'AWS_DEFAULT_REGION', value: params.AWS_DEFAULT_REGION),
+                                    string(name: 'ENDPOINT', value: params.ENDPOINT),
+                                    string(name: 'METRIC_SUFFIX', value: "-gamma"),
+                                    string(name: 'VIEWER_WAIT_MINUTES', value: params.VIEWER_WAIT_MINUTES),
+                                    string(name: 'VIEWER_SESSION_DURATION_SECONDS', value: params.VIEWER_SESSION_DURATION_SECONDS),
+                                    booleanParam(name: 'FIRST_ITERATION', value: true),
+                                    booleanParam(name: 'RESCHEDULE', value: params.RESCHEDULE),
+                                ],
+                                wait: true,
+                                propagate: false
+                            )
+                            echo "StorageThreeViewers result: ${result.result}"
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    post {
+        success {
+            echo "All gamma tests completed successfully!"
+        }
+        failure {
+            echo "Some gamma tests failed. Check individual test results."
+        }
+        always {
+            echo "=========================================="
+            echo "Gamma Test Summary"
+            echo "=========================================="
+            echo "Endpoint: ${params.ENDPOINT}"
+            echo "Region: ${params.AWS_DEFAULT_REGION}"
+            echo "Build result: ${currentBuild.result ?: 'SUCCESS'}"
+            echo "=========================================="
+        }
+    }
+}

--- a/canary/webrtc-c/jobs/gamma_runner.groovy
+++ b/canary/webrtc-c/jobs/gamma_runner.groovy
@@ -1,0 +1,472 @@
+import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
+
+/**
+ * Gamma Test Runner
+ * 
+ * This is a dedicated runner for gamma tests. It runs the WebRTC storage master
+ * and JS viewer tests against a custom endpoint.
+ * 
+ * Key differences from production runner:
+ *   - No automatic rescheduling (runs once and stops)
+ *   - Simplified configuration
+ *   - Dedicated for gamma/testing purposes
+ * 
+ * Do not run this directly - use webrtc-gamma-orchestrator instead.
+ */
+
+START_TIMESTAMP = new Date().getTime()
+RUNNING_NODES_IN_BUILDING = 0
+HAS_ERROR = false
+
+def buildWebRTCProject(thing_prefix) {
+    checkout([$class: 'GitSCM', branches: [[name: params.GIT_HASH]],
+              userRemoteConfigs: [[url: params.GIT_URL]]])
+
+    def configureCmd = "cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=\"\$PWD\""
+
+    sh """
+        cd ./canary/webrtc-c/scripts &&
+        chmod a+x cert_setup.sh &&
+        ./cert_setup.sh ${thing_prefix} &&
+        cd .. &&
+        mkdir -p build &&
+        cd build &&
+        ${configureCmd} &&
+        make"""
+}
+
+def withRunnerWrapper(envs, fn) {
+    withEnv(envs) {
+        try {
+            fn()
+        } catch (FlowInterruptedException err) {
+            echo 'Aborted due to cancellation'
+            throw err
+        } catch (err) {
+            HAS_ERROR = true
+            unstable err.toString()
+        }
+    }
+}
+
+def runViewerSessions(viewerId = "", waitMinutes = 2, viewerCount = "1", staggerDelaySeconds = 0) {
+    def workspaceName = "${env.JOB_NAME}-${viewerId ?: 'viewer'}-${BUILD_NUMBER}"
+    ws(workspaceName) {
+        try {
+            deleteDir()
+            checkout([$class: 'GitSCM', branches: [[name: params.GIT_HASH]],
+                      userRemoteConfigs: [[url: params.GIT_URL]]])
+            
+            // Wait for master to build before starting viewers
+            if (waitMinutes > 0) {
+                echo "Waiting ${waitMinutes} minutes for master to build"
+                sleep waitMinutes * 60
+            }
+            
+            // Staggered start delay to avoid all viewers starting at the exact same time
+            if (staggerDelaySeconds > 0) {
+                echo "Staggered start - waiting ${staggerDelaySeconds} seconds before starting ${viewerId ?: 'viewer'}"
+                sleep staggerDelaySeconds
+            }
+            
+            def endpointValue = params.ENDPOINT ?: ''
+            def metricSuffixValue = params.METRIC_SUFFIX ?: ''
+            
+            echo "=========================================="
+            echo "Viewer Configuration"
+            echo "=========================================="
+            echo "Viewer ID: ${viewerId ?: 'default'}"
+            echo "Endpoint: ${endpointValue}"
+            echo "Metric Suffix: ${metricSuffixValue}"
+            echo "Region: ${params.AWS_DEFAULT_REGION}"
+            echo "=========================================="
+            
+            // Run 3 viewer sessions
+            for (int session = 1; session <= 3; session++) {
+                echo "Starting ${viewerId ? viewerId + ' ' : ''}session ${session}/3"
+                
+                def viewerSessionDuration = (params.VIEWER_SESSION_DURATION_SECONDS != null && params.VIEWER_SESSION_DURATION_SECONDS.toString().trim() != '') 
+                    ? params.VIEWER_SESSION_DURATION_SECONDS 
+                    : '600'
+                
+                try {
+                    sh """
+                        export JOB_NAME="${env.JOB_NAME}"
+                        export RUNNER_LABEL="${params.RUNNER_LABEL}"
+                        export AWS_DEFAULT_REGION="${params.AWS_DEFAULT_REGION}"
+                        export DURATION_IN_SECONDS="${viewerSessionDuration}"
+                        export FORCE_TURN="${params.FORCE_TURN ?: 'false'}"
+                        export VIEWER_COUNT="${viewerCount}"
+                        export VIEWER_ID="${viewerId}"
+                        export CLIENT_ID="${viewerId ? viewerId.toLowerCase() + '-' : 'viewer-'}session-${session}-${BUILD_NUMBER}"
+                        export ENDPOINT="${endpointValue}"
+                        export METRIC_SUFFIX="${metricSuffixValue}"
+                        
+                        ./canary/webrtc-c/scripts/setup-storage-viewer.sh
+                    """
+                } catch (FlowInterruptedException err) {
+                    echo 'Aborted due to cancellation'
+                    throw err
+                } catch (err) {
+                    HAS_ERROR = true
+                    unstable err.toString()
+                }
+                
+                if (session < 3) {
+                    echo "${viewerId ? viewerId + ' ' : ''}session ${session} completed. Waiting 1 minute before next session."
+                    sleep 60
+                }
+            }
+            echo "All 3 ${viewerId ? viewerId + ' ' : ''}sessions completed"
+        } finally {
+            deleteDir()
+        }
+    }
+}
+
+def buildStorageCanary(params) {
+    def scripts_dir = "$WORKSPACE/canary/webrtc-c/scripts"
+    def thing_prefix = "${env.JOB_NAME}-${params.RUNNER_LABEL}"
+    def endpoint = "${scripts_dir}/iot-credential-provider.txt"
+    def core_cert_file = "${scripts_dir}/${thing_prefix}_certificate.pem"
+    def private_key_file = "${scripts_dir}/${thing_prefix}_private.key"
+    def role_alias = "${thing_prefix}_role_alias"
+    def thing_name = "${thing_prefix}_thing"
+
+    def envs = [
+        'AWS_KVS_LOG_LEVEL': params.AWS_KVS_LOG_LEVEL,
+        'CANARY_USE_IOT_PROVIDER': params.USE_IOT ?: false,
+        'CANARY_LABEL': params.SCENARIO_LABEL,
+        'CANARY_DURATION_IN_SECONDS': params.DURATION_IN_SECONDS,
+        'CANARY_USE_TURN': params.USE_TURN ?: false,
+        'CANARY_TRICKLE_ICE': params.TRICKLE_ICE ?: false,
+        'CANARY_LOG_GROUP_NAME': params.LOG_GROUP_NAME,
+        'CANARY_LOG_STREAM_NAME': "${params.RUNNER_LABEL}-StorageMaster-${START_TIMESTAMP}",
+        'CANARY_CLIENT_ID': "Master",
+        'CANARY_IS_MASTER': true,
+        'CANARY_CHANNEL_NAME': "${env.JOB_NAME}-${params.RUNNER_LABEL}",
+        'AWS_DEFAULT_REGION': params.AWS_DEFAULT_REGION,
+        'CONTROL_PLANE_URI': params.ENDPOINT ?: '',
+        'AWS_IOT_CORE_CREDENTIAL_ENDPOINT': "${endpoint}",
+        'AWS_IOT_CORE_CERT': "${core_cert_file}",
+        'AWS_IOT_CORE_PRIVATE_KEY': "${private_key_file}",
+        'AWS_IOT_CORE_ROLE_ALIAS': "${role_alias}",
+        'AWS_IOT_CORE_THING_NAME': "${thing_name}"
+    ].collect{ k, v -> "${k}=${v}" }
+
+    RUNNING_NODES_IN_BUILDING++
+    if (params.FIRST_ITERATION) {
+        deleteDir()
+    }
+    buildWebRTCProject(thing_prefix)
+    RUNNING_NODES_IN_BUILDING--
+    
+    waitUntil {
+        RUNNING_NODES_IN_BUILDING == 0
+    }
+
+    withRunnerWrapper(envs) {
+        sh """
+            cd ./canary/webrtc-c/build &&
+            ./kvsWebrtcStorageSample"""
+    }
+}
+
+pipeline {
+    agent {
+        label params.MASTER_NODE_LABEL
+    }
+
+    parameters {
+        string(name: 'AWS_KVS_LOG_LEVEL', defaultValue: '2')
+        string(name: 'LOG_GROUP_NAME', defaultValue: 'WebrtcSDK')
+        string(name: 'MASTER_NODE_LABEL', defaultValue: 'webrtc-storage-master')
+        string(name: 'STORAGE_VIEWER_NODE_LABEL', defaultValue: 'webrtc-storage-viewer')
+        string(name: 'STORAGE_VIEWER_ONE_NODE_LABEL', defaultValue: 'webrtc-storage-multi-viewer-1')
+        string(name: 'STORAGE_VIEWER_TWO_NODE_LABEL', defaultValue: 'webrtc-storage-multi-viewer-2')
+        string(name: 'STORAGE_VIEWER_THREE_NODE_LABEL', defaultValue: 'webrtc-storage-consumer')
+        string(name: 'RUNNER_LABEL', defaultValue: 'GammaTest')
+        string(name: 'SCENARIO_LABEL', defaultValue: 'GammaTest')
+        string(name: 'DURATION_IN_SECONDS', defaultValue: '600')
+        string(name: 'GIT_URL', defaultValue: 'https://github.com/aws-samples/amazon-kinesis-video-streams-demos.git')
+        string(name: 'GIT_HASH', defaultValue: 'master')
+        string(name: 'AWS_DEFAULT_REGION', defaultValue: 'us-west-2')
+        string(name: 'ENDPOINT', defaultValue: '', description: 'Custom endpoint URL (e.g., gamma endpoint)')
+        string(name: 'METRIC_SUFFIX', defaultValue: '-gamma')
+        string(name: 'VIEWER_WAIT_MINUTES', defaultValue: '2', description: 'Minutes to wait for master to build')
+        string(name: 'VIEWER_SESSION_DURATION_SECONDS', defaultValue: '600', description: 'Duration in seconds for each viewer session (default 10 minutes)')
+        booleanParam(name: 'DEBUG_LOG_SDP', defaultValue: true)
+        booleanParam(name: 'FIRST_ITERATION', defaultValue: true)
+        booleanParam(name: 'JS_STORAGE_VIEWER_JOIN', defaultValue: false)
+        booleanParam(name: 'JS_STORAGE_TWO_VIEWERS', defaultValue: false)
+        booleanParam(name: 'JS_STORAGE_THREE_VIEWERS', defaultValue: false)
+        booleanParam(name: 'RESCHEDULE', defaultValue: false, description: 'Whether to reschedule after completion')
+        booleanParam(name: 'USE_TURN', defaultValue: false)
+        booleanParam(name: 'USE_IOT', defaultValue: false)
+        booleanParam(name: 'TRICKLE_ICE', defaultValue: false)
+        booleanParam(name: 'FORCE_TURN', defaultValue: false)
+    }
+    
+    environment {
+        AWS_KVS_STS_ROLE_ARN = credentials('CANARY_STS_ROLE_ARN')
+    }
+
+    stages {
+        stage('Fetch STS credentials') {
+            steps {
+                script {
+                    def assumeRoleOutput = sh(script: 'aws sts assume-role --role-arn $AWS_KVS_STS_ROLE_ARN --role-session-name roleSessionName --duration-seconds 43200 --output json',
+                                                returnStdout: true).trim()
+                    def assumeRoleJson = readJSON text: assumeRoleOutput
+
+                    env.AWS_ACCESS_KEY_ID = assumeRoleJson.Credentials.AccessKeyId
+                    env.AWS_SECRET_ACCESS_KEY = assumeRoleJson.Credentials.SecretAccessKey
+                    env.AWS_SESSION_TOKEN = assumeRoleJson.Credentials.SessionToken
+                }
+            }
+        }
+
+        stage('Set build description') {
+            steps {
+                script {
+                    currentBuild.displayName = "${params.RUNNER_LABEL} [#${BUILD_NUMBER}]"
+                    currentBuild.description = "Endpoint: ${params.ENDPOINT}\nRegion: ${params.AWS_DEFAULT_REGION}"
+                }
+            }
+        }
+
+        stage('Preparation') {
+            steps {
+                script {
+                    echo "=========================================="
+                    echo "Gamma Runner Configuration"
+                    echo "=========================================="
+                    echo "Endpoint: ${params.ENDPOINT}"
+                    echo "Region: ${params.AWS_DEFAULT_REGION}"
+                    echo "Viewer Wait: ${params.VIEWER_WAIT_MINUTES} minutes"
+                    echo "Test Type: ${params.JS_STORAGE_VIEWER_JOIN ? '1 Viewer' : params.JS_STORAGE_TWO_VIEWERS ? '2 Viewers' : params.JS_STORAGE_THREE_VIEWERS ? '3 Viewers' : 'Unknown'}"
+                    echo "=========================================="
+                }
+            }
+        }
+
+        stage('Single Viewer with Continuous Master') {
+            when {
+                equals expected: true, actual: params.JS_STORAGE_VIEWER_JOIN
+            }
+            parallel {
+                stage('Continuous StorageMaster') {
+                    agent {
+                        label params.MASTER_NODE_LABEL
+                    }
+                    steps {
+                        script {
+                            def viewerWaitMin = (params.VIEWER_WAIT_MINUTES != null && params.VIEWER_WAIT_MINUTES.toString().trim() != '') ? params.VIEWER_WAIT_MINUTES.toInteger() : 2
+                            def sessionDurationSec = (params.VIEWER_SESSION_DURATION_SECONDS != null && params.VIEWER_SESSION_DURATION_SECONDS.toString().trim() != '') ? params.VIEWER_SESSION_DURATION_SECONDS.toInteger() : 600
+                            // Master duration = viewer wait + 3 sessions + 2 inter-session gaps + 10 min buffer
+                            def masterDuration = (viewerWaitMin * 60) + (3 * sessionDurationSec) + (2 * 60) + 600
+                            def mutableParams = [:] + params
+                            mutableParams.DURATION_IN_SECONDS = "${masterDuration}"
+                            buildStorageCanary(mutableParams)
+                        }
+                    }
+                }
+                stage('StorageViewer') {
+                    agent {
+                        label params.STORAGE_VIEWER_NODE_LABEL
+                    }
+                    steps {
+                        script {
+                            def waitMins = (params.VIEWER_WAIT_MINUTES != null && params.VIEWER_WAIT_MINUTES.toString().trim() != '') 
+                                ? params.VIEWER_WAIT_MINUTES.toInteger() 
+                                : 2
+                            runViewerSessions("", waitMins, "1")
+                        }
+                    }
+                }
+            }
+        }
+
+        stage('Two Viewers with Continuous Master') {
+            when {
+                equals expected: true, actual: params.JS_STORAGE_TWO_VIEWERS
+            }
+            parallel {
+                stage('Continuous StorageMaster') {
+                    agent {
+                        label params.MASTER_NODE_LABEL
+                    }
+                    steps {
+                        script {
+                            def viewerWaitMin = (params.VIEWER_WAIT_MINUTES != null && params.VIEWER_WAIT_MINUTES.toString().trim() != '') ? params.VIEWER_WAIT_MINUTES.toInteger() : 2
+                            def sessionDurationSec = (params.VIEWER_SESSION_DURATION_SECONDS != null && params.VIEWER_SESSION_DURATION_SECONDS.toString().trim() != '') ? params.VIEWER_SESSION_DURATION_SECONDS.toInteger() : 600
+                            // Master duration = viewer wait + 3 sessions + 2 inter-session gaps + 10 min buffer
+                            def masterDuration = (viewerWaitMin * 60) + (3 * sessionDurationSec) + (2 * 60) + 600
+                            def mutableParams = [:] + params
+                            mutableParams.DURATION_IN_SECONDS = "${masterDuration}"
+                            buildStorageCanary(mutableParams)
+                        }
+                    }
+                }
+                stage('StorageViewer1') {
+                    agent {
+                        label params.STORAGE_VIEWER_ONE_NODE_LABEL
+                    }
+                    steps {
+                        script {
+                            def waitMins = (params.VIEWER_WAIT_MINUTES != null && params.VIEWER_WAIT_MINUTES.toString().trim() != '') 
+                                ? params.VIEWER_WAIT_MINUTES.toInteger() 
+                                : 2
+                            // Viewer1 starts immediately (0 second stagger)
+                            runViewerSessions("Viewer1", waitMins, "2", 0)
+                        }
+                    }
+                }
+                stage('StorageViewer2') {
+                    agent {
+                        label params.STORAGE_VIEWER_TWO_NODE_LABEL
+                    }
+                    steps {
+                        script {
+                            def waitMins = (params.VIEWER_WAIT_MINUTES != null && params.VIEWER_WAIT_MINUTES.toString().trim() != '') 
+                                ? params.VIEWER_WAIT_MINUTES.toInteger() 
+                                : 2
+                            // Viewer2 starts 15 seconds after Viewer1
+                            runViewerSessions("Viewer2", waitMins, "2", 15)
+                        }
+                    }
+                }
+            }
+        }
+
+        stage('Three Viewers with Continuous Master') {
+            when {
+                equals expected: true, actual: params.JS_STORAGE_THREE_VIEWERS
+            }
+            parallel {
+                stage('Continuous StorageMaster') {
+                    agent {
+                        label params.MASTER_NODE_LABEL
+                    }
+                    steps {
+                        script {
+                            def viewerWaitMin = (params.VIEWER_WAIT_MINUTES != null && params.VIEWER_WAIT_MINUTES.toString().trim() != '') ? params.VIEWER_WAIT_MINUTES.toInteger() : 2
+                            def sessionDurationSec = (params.VIEWER_SESSION_DURATION_SECONDS != null && params.VIEWER_SESSION_DURATION_SECONDS.toString().trim() != '') ? params.VIEWER_SESSION_DURATION_SECONDS.toInteger() : 600
+                            // Master duration = viewer wait + 3 sessions + 2 inter-session gaps + 10 min buffer
+                            def masterDuration = (viewerWaitMin * 60) + (3 * sessionDurationSec) + (2 * 60) + 600
+                            def mutableParams = [:] + params
+                            mutableParams.DURATION_IN_SECONDS = "${masterDuration}"
+                            buildStorageCanary(mutableParams)
+                        }
+                    }
+                }
+                stage('StorageViewer1') {
+                    agent {
+                        label params.STORAGE_VIEWER_ONE_NODE_LABEL
+                    }
+                    steps {
+                        script {
+                            def waitMins = (params.VIEWER_WAIT_MINUTES != null && params.VIEWER_WAIT_MINUTES.toString().trim() != '') 
+                                ? params.VIEWER_WAIT_MINUTES.toInteger() 
+                                : 2
+                            // Viewer1 starts immediately (0 second stagger)
+                            runViewerSessions("Viewer1", waitMins, "3", 0)
+                        }
+                    }
+                }
+                stage('StorageViewer2') {
+                    agent {
+                        label params.STORAGE_VIEWER_TWO_NODE_LABEL
+                    }
+                    steps {
+                        script {
+                            def waitMins = (params.VIEWER_WAIT_MINUTES != null && params.VIEWER_WAIT_MINUTES.toString().trim() != '') 
+                                ? params.VIEWER_WAIT_MINUTES.toInteger() 
+                                : 2
+                            // Viewer2 starts 15 seconds after Viewer1
+                            runViewerSessions("Viewer2", waitMins, "3", 15)
+                        }
+                    }
+                }
+                stage('StorageViewer3') {
+                    agent {
+                        label params.STORAGE_VIEWER_THREE_NODE_LABEL
+                    }
+                    steps {
+                        script {
+                            def waitMins = (params.VIEWER_WAIT_MINUTES != null && params.VIEWER_WAIT_MINUTES.toString().trim() != '') 
+                                ? params.VIEWER_WAIT_MINUTES.toInteger() 
+                                : 2
+                            // Viewer3 starts 30 seconds after Viewer1
+                            runViewerSessions("Viewer3", waitMins, "3", 30)
+                        }
+                    }
+                }
+            }
+        }
+
+        stage('Unset credentials') {
+            steps {
+                script {
+                    env.AWS_ACCESS_KEY_ID = ''
+                    env.AWS_SECRET_ACCESS_KEY = ''
+                    env.AWS_SESSION_TOKEN = ''
+                }
+            }
+        }
+
+        stage('Reschedule') {
+            when {
+                equals expected: true, actual: params.RESCHEDULE
+            }
+            steps {
+                build(
+                    job: env.JOB_NAME,
+                    parameters: [
+                        string(name: 'AWS_KVS_LOG_LEVEL', value: params.AWS_KVS_LOG_LEVEL),
+                        string(name: 'LOG_GROUP_NAME', value: params.LOG_GROUP_NAME),
+                        string(name: 'MASTER_NODE_LABEL', value: params.MASTER_NODE_LABEL),
+                        string(name: 'STORAGE_VIEWER_NODE_LABEL', value: params.STORAGE_VIEWER_NODE_LABEL),
+                        string(name: 'STORAGE_VIEWER_ONE_NODE_LABEL', value: params.STORAGE_VIEWER_ONE_NODE_LABEL),
+                        string(name: 'STORAGE_VIEWER_TWO_NODE_LABEL', value: params.STORAGE_VIEWER_TWO_NODE_LABEL),
+                        string(name: 'STORAGE_VIEWER_THREE_NODE_LABEL', value: params.STORAGE_VIEWER_THREE_NODE_LABEL),
+                        string(name: 'RUNNER_LABEL', value: params.RUNNER_LABEL),
+                        string(name: 'SCENARIO_LABEL', value: params.SCENARIO_LABEL),
+                        string(name: 'DURATION_IN_SECONDS', value: params.DURATION_IN_SECONDS),
+                        string(name: 'GIT_URL', value: params.GIT_URL),
+                        string(name: 'GIT_HASH', value: params.GIT_HASH),
+                        string(name: 'AWS_DEFAULT_REGION', value: params.AWS_DEFAULT_REGION),
+                        string(name: 'ENDPOINT', value: params.ENDPOINT),
+                        string(name: 'METRIC_SUFFIX', value: params.METRIC_SUFFIX),
+                        string(name: 'VIEWER_WAIT_MINUTES', value: params.VIEWER_WAIT_MINUTES),
+                        string(name: 'VIEWER_SESSION_DURATION_SECONDS', value: params.VIEWER_SESSION_DURATION_SECONDS),
+                        booleanParam(name: 'DEBUG_LOG_SDP', value: params.DEBUG_LOG_SDP),
+                        booleanParam(name: 'FIRST_ITERATION', value: false),
+                        booleanParam(name: 'JS_STORAGE_VIEWER_JOIN', value: params.JS_STORAGE_VIEWER_JOIN),
+                        booleanParam(name: 'JS_STORAGE_TWO_VIEWERS', value: params.JS_STORAGE_TWO_VIEWERS),
+                        booleanParam(name: 'JS_STORAGE_THREE_VIEWERS', value: params.JS_STORAGE_THREE_VIEWERS),
+                        booleanParam(name: 'RESCHEDULE', value: params.RESCHEDULE),
+                        booleanParam(name: 'USE_TURN', value: params.USE_TURN),
+                        booleanParam(name: 'USE_IOT', value: params.USE_IOT),
+                        booleanParam(name: 'TRICKLE_ICE', value: params.TRICKLE_ICE),
+                        booleanParam(name: 'FORCE_TURN', value: params.FORCE_TURN),
+                    ],
+                    wait: false
+                )
+            }
+        }
+    }
+    
+    post {
+        always {
+            script {
+                echo "=========================================="
+                echo "Gamma Runner Summary"
+                echo "=========================================="
+                echo "Build result: ${currentBuild.result ?: 'SUCCESS'}"
+                echo "Has errors: ${HAS_ERROR}"
+                echo "=========================================="
+            }
+        }
+    }
+}

--- a/canary/webrtc-c/jobs/gamma_seed.groovy
+++ b/canary/webrtc-c/jobs/gamma_seed.groovy
@@ -1,0 +1,99 @@
+import java.lang.reflect.*;
+import jenkins.model.*;
+import org.jenkinsci.plugins.scriptsecurity.scripts.*;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.*;
+
+/**
+ * Gamma Seed Job
+ * 
+ * This seed creates dedicated gamma testing jobs that are completely independent
+ * from the production canary jobs. Running this seed will create:
+ *   - webrtc-gamma-orchestrator: The main gamma test orchestrator
+ *   - webrtc-gamma-runner: A dedicated runner for gamma tests
+ * 
+ * Usage:
+ *   1. Run this seed job
+ *   2. Go to webrtc-gamma-orchestrator
+ *   3. Click "Build with Parameters"
+ *   4. Enter the gamma endpoint URL
+ *   5. Click "Build"
+ */
+
+NAMESPACE = "webrtc-gamma"
+WORKSPACE = "canary/webrtc-c"
+JOBS_DIR = "$WORKSPACE/jobs"
+NUM_LOGS = 30
+
+void approveSignatures(ArrayList<String> signatures) {
+    scriptApproval = ScriptApproval.get()
+    alreadyApproved = new HashSet<>(Arrays.asList(scriptApproval.getApprovedSignatures()))
+    signatures.each {
+        if (!alreadyApproved.contains(it)) {
+            scriptApproval.approveSignature(it)
+        }
+    }
+}
+
+approveSignatures([
+    "method hudson.model.ItemGroup getAllItems java.lang.Class",
+    "method hudson.model.Job getBuilds",
+    "method hudson.model.Job getLastBuild",
+    "method hudson.model.Job isBuilding",
+    "method hudson.model.Run getTimeInMillis",
+    "method hudson.model.Run isBuilding",
+    "method jenkins.model.Jenkins getItemByFullName java.lang.String",
+    "method jenkins.model.ParameterizedJobMixIn\$ParameterizedJob isDisabled",
+    "method jenkins.model.ParameterizedJobMixIn\$ParameterizedJob setDisabled boolean",
+    "method org.jenkinsci.plugins.workflow.job.WorkflowRun doKill",
+    "staticMethod jenkins.model.Jenkins getInstance",
+    "staticField java.lang.Long MAX_VALUE"
+])
+
+// Create the gamma orchestrator job
+pipelineJob("${NAMESPACE}-orchestrator") {
+    description("""
+        <h2>Gamma Test Orchestrator</h2>
+        <p>Runs WebRTC storage viewer tests against a custom endpoint (e.g., gamma).</p>
+        <h3>Usage:</h3>
+        <ol>
+            <li>Click "Build with Parameters"</li>
+            <li>Enter the gamma endpoint URL</li>
+            <li>Select which tests to run</li>
+            <li>Click "Build"</li>
+        </ol>
+    """)
+    throttleConcurrentBuilds {
+        maxTotal(1)
+    }
+    logRotator {
+        numToKeep(NUM_LOGS)
+    }
+    definition {
+        cps {
+            script(readFileFromWorkspace("${JOBS_DIR}/gamma_orchestrator.groovy"))
+            sandbox()
+        }
+    }
+}
+
+// Create a dedicated gamma runner job
+pipelineJob("${NAMESPACE}-runner") {
+    description("""
+        <h2>Gamma Test Runner</h2>
+        <p>Dedicated runner for gamma tests. Do not run directly - use the orchestrator.</p>
+    """)
+    logRotator {
+        numToKeep(NUM_LOGS)
+    }
+    definition {
+        cps {
+            script(readFileFromWorkspace("${JOBS_DIR}/gamma_runner.groovy"))
+            sandbox()
+        }
+    }
+}
+
+// Gamma seed completed! Created jobs:
+//   - webrtc-gamma-orchestrator
+//   - webrtc-gamma-runner
+// To run gamma tests, go to webrtc-gamma-orchestrator and click 'Build with Parameters'

--- a/canary/webrtc-c/jobs/orchestrator.groovy
+++ b/canary/webrtc-c/jobs/orchestrator.groovy
@@ -402,11 +402,12 @@ pipeline {
                                 booleanParam(name: 'USE_IOT', value: false),
                                 booleanParam(name: 'JS_STORAGE_VIEWER_JOIN', value: true),
                                 string(name: 'DURATION_IN_SECONDS', value: STORAGE_WITH_VIEWER_DURATION_IN_SECONDS.toString()),
-                                string(name: 'MASTER_NODE_LABEL', value: "webrtc-storage-master-2"),
+                                string(name: 'MASTER_NODE_LABEL', value: "webrtc-storage-master"),
                                 string(name: 'STORAGE_VIEWER_NODE_LABEL', value: "webrtc-storage-viewer"),
                                 string(name: 'RUNNER_LABEL', value: "StorageWithViewer"),
                                 string(name: 'SCENARIO_LABEL', value: "StorageWithViewer"),
                                 string(name: 'AWS_DEFAULT_REGION', value: "us-west-2"),
+                                string(name: 'VIEWER_WAIT_MINUTES', value: "55"),
                             ],
                             wait: false
                         )
@@ -424,13 +425,14 @@ pipeline {
                                 booleanParam(name: 'JS_STORAGE_VIEWER_JOIN', value: false),
                                 booleanParam(name: 'JS_STORAGE_TWO_VIEWERS', value: true),
                                 string(name: 'DURATION_IN_SECONDS', value: STORAGE_WITH_VIEWER_DURATION_IN_SECONDS.toString()),
-                                string(name: 'MASTER_NODE_LABEL', value: "webrtc-storage-master-2"),
+                                string(name: 'MASTER_NODE_LABEL', value: "webrtc-storage-master"),
                                 string(name: 'STORAGE_VIEWER_NODE_LABEL', value: "webrtc-storage-viewer"),
                                 string(name: 'STORAGE_VIEWER_ONE_NODE_LABEL', value: "webrtc-storage-multi-viewer-1"),
                                 string(name: 'STORAGE_VIEWER_TWO_NODE_LABEL', value: "webrtc-storage-multi-viewer-2"),
                                 string(name: 'RUNNER_LABEL', value: "StorageTwoViewers"),
                                 string(name: 'SCENARIO_LABEL', value: "StorageTwoViewers"),
                                 string(name: 'AWS_DEFAULT_REGION', value: "us-west-2"),
+                                string(name: 'VIEWER_WAIT_MINUTES', value: "55"),
                             ],
                             wait: false
                         )
@@ -449,7 +451,7 @@ pipeline {
                                 booleanParam(name: 'JS_STORAGE_TWO_VIEWERS', value: false),
                                 booleanParam(name: 'JS_STORAGE_THREE_VIEWERS', value: true),
                                 string(name: 'DURATION_IN_SECONDS', value: STORAGE_WITH_VIEWER_DURATION_IN_SECONDS.toString()),
-                                string(name: 'MASTER_NODE_LABEL', value: "webrtc-storage-master-2"),
+                                string(name: 'MASTER_NODE_LABEL', value: "webrtc-storage-master"),
                                 string(name: 'STORAGE_VIEWER_NODE_LABEL', value: "webrtc-storage-viewer"),
                                 string(name: 'STORAGE_VIEWER_ONE_NODE_LABEL', value: "webrtc-storage-multi-viewer-1"),
                                 string(name: 'STORAGE_VIEWER_TWO_NODE_LABEL', value: "webrtc-storage-multi-viewer-2"),
@@ -457,6 +459,7 @@ pipeline {
                                 string(name: 'RUNNER_LABEL', value: "StorageThreeViewers"),
                                 string(name: 'SCENARIO_LABEL', value: "StorageThreeViewers"),
                                 string(name: 'AWS_DEFAULT_REGION', value: "us-west-2"),
+                                string(name: 'VIEWER_WAIT_MINUTES', value: "55"),
                             ],
                             wait: false
                         )

--- a/canary/webrtc-c/jobs/runner.groovy
+++ b/canary/webrtc-c/jobs/runner.groovy
@@ -162,7 +162,7 @@ def buildSignaling(params) {
     }
 }
 
-def runViewerSessions(viewerId = "", waitMinutes = 10, viewerCount = "1") {
+def runViewerSessions(viewerId = "", waitMinutes = 10, viewerCount = "1", staggerDelaySeconds = 0) {
     // Create unique workspace for each viewer to prevent Git conflicts
     def workspaceName = "${env.JOB_NAME}-${viewerId ?: 'viewer'}-${BUILD_NUMBER}"
     ws(workspaceName) {
@@ -171,24 +171,40 @@ def runViewerSessions(viewerId = "", waitMinutes = 10, viewerCount = "1") {
             checkout([$class: 'GitSCM', branches: [[name: params.GIT_HASH ]],
                       userRemoteConfigs: [[url: params.GIT_URL]]])
             
-            if (params.FIRST_ITERATION) {
-                echo "First iteration - waiting ${waitMinutes} minutes for master to build"
+            if (waitMinutes > 0) {
+                echo "Waiting ${waitMinutes} minutes for master to build"
                 sleep waitMinutes * 60
             }
             
+            // Staggered start delay to avoid all viewers starting at the exact same time
+            if (staggerDelaySeconds > 0) {
+                echo "Staggered start - waiting ${staggerDelaySeconds} seconds before starting ${viewerId ?: 'viewer'}"
+                sleep staggerDelaySeconds
+            }
+            
+            // Capture endpoint value before loop to ensure it's available
+            def endpointValue = params.ENDPOINT ?: ''
+            def metricSuffixValue = params.METRIC_SUFFIX ?: ''
+            
             for (int session = 1; session <= 3; session++) {
                 echo "Starting ${viewerId ? viewerId + ' ' : ''}session ${session}/3"
+                echo "DEBUG: ENDPOINT value = '${endpointValue}'"
+                echo "DEBUG: METRIC_SUFFIX value = '${metricSuffixValue}'"
                 
                 try {
                     sh """
                         export JOB_NAME="${env.JOB_NAME}"
                         export RUNNER_LABEL="${params.RUNNER_LABEL}"
                         export AWS_DEFAULT_REGION="${params.AWS_DEFAULT_REGION}"
-                        export DURATION_IN_SECONDS="180"
+                        export DURATION_IN_SECONDS="${(params.VIEWER_SESSION_DURATION_SECONDS != null && params.VIEWER_SESSION_DURATION_SECONDS.toString().trim() != '') ? params.VIEWER_SESSION_DURATION_SECONDS : '600'}"
                         export FORCE_TURN="${params.FORCE_TURN}"
                         export VIEWER_COUNT="${viewerCount}"
                         export VIEWER_ID="${viewerId}"
                         export CLIENT_ID="${viewerId ? viewerId.toLowerCase() + '-' : 'viewer-'}session-${session}-${BUILD_NUMBER}"
+                        export ENDPOINT="${endpointValue}"
+                        export METRIC_SUFFIX="${metricSuffixValue}"
+                        
+                        echo "Shell ENDPOINT: \$ENDPOINT"
                         
                         ./canary/webrtc-c/scripts/setup-storage-viewer.sh
                     """
@@ -242,7 +258,9 @@ def buildStorageCanary(isConsumer, params) {
       'CANARY_LOG_STREAM_NAME': "${params.RUNNER_LABEL}-StorageMaster-${START_TIMESTAMP}",
       'CANARY_CLIENT_ID': "Master",
       'CANARY_IS_MASTER': true,
-      'CANARY_CHANNEL_NAME': "${env.JOB_NAME}-${params.RUNNER_LABEL}"
+      'CANARY_CHANNEL_NAME': "${env.JOB_NAME}-${params.RUNNER_LABEL}",
+      'AWS_DEFAULT_REGION': params.AWS_DEFAULT_REGION,
+      'CONTROL_PLANE_URI': params.ENDPOINT ?: ''
     ]
 
     def consumerEnvs = [
@@ -320,6 +338,10 @@ pipeline {
         booleanParam(name: 'JS_STORAGE_VIEWER_JOIN', defaultValue: false)
         booleanParam(name: 'JS_STORAGE_TWO_VIEWERS', defaultValue: false)
         booleanParam(name: 'JS_STORAGE_THREE_VIEWERS', defaultValue: false)
+        string(name: 'ENDPOINT', defaultValue: '')
+        string(name: 'METRIC_SUFFIX', defaultValue: '')
+        string(name: 'VIEWER_WAIT_MINUTES', defaultValue: '55')
+        string(name: 'VIEWER_SESSION_DURATION_SECONDS', defaultValue: '600', description: 'Duration in seconds for each viewer session (default 10 minutes)')
     }
     
     // Set the role ARN to environment to avoid string interpolation to follow Jenkins security guidelines.
@@ -523,8 +545,12 @@ pipeline {
                     }
                     steps {
                         script {
+                            def viewerWaitMin = (params.VIEWER_WAIT_MINUTES != null && params.VIEWER_WAIT_MINUTES.toString().trim() != '') ? params.VIEWER_WAIT_MINUTES.toInteger() : 55
+                            def sessionDurationSec = (params.VIEWER_SESSION_DURATION_SECONDS != null && params.VIEWER_SESSION_DURATION_SECONDS.toString().trim() != '') ? params.VIEWER_SESSION_DURATION_SECONDS.toInteger() : 600
+                            // Master duration = viewer wait + 3 sessions + 2 inter-session gaps + 10 min buffer
+                            def masterDuration = (viewerWaitMin * 60) + (3 * sessionDurationSec) + (2 * 60) + 600
                             def mutableParams = [:] + params
-                            mutableParams.DURATION_IN_SECONDS = "1380"
+                            mutableParams.DURATION_IN_SECONDS = "${masterDuration}"
                             buildStorageCanary(false, mutableParams)
                         }
                     }
@@ -535,7 +561,8 @@ pipeline {
                     }
                     steps {
                         script {
-                            runViewerSessions("", 55, "1")
+                            def waitMins = (params.VIEWER_WAIT_MINUTES != null && params.VIEWER_WAIT_MINUTES.toString().trim() != '') ? params.VIEWER_WAIT_MINUTES.toInteger() : 55
+                            runViewerSessions("", waitMins, "1")
                         }
                     }
                 }
@@ -553,8 +580,12 @@ pipeline {
                     }
                     steps {
                         script {
+                            def viewerWaitMin = (params.VIEWER_WAIT_MINUTES != null && params.VIEWER_WAIT_MINUTES.toString().trim() != '') ? params.VIEWER_WAIT_MINUTES.toInteger() : 55
+                            def sessionDurationSec = (params.VIEWER_SESSION_DURATION_SECONDS != null && params.VIEWER_SESSION_DURATION_SECONDS.toString().trim() != '') ? params.VIEWER_SESSION_DURATION_SECONDS.toInteger() : 600
+                            // Master duration = viewer wait + 3 sessions + 2 inter-session gaps + 10 min buffer
+                            def masterDuration = (viewerWaitMin * 60) + (3 * sessionDurationSec) + (2 * 60) + 600
                             def mutableParams = [:] + params
-                            mutableParams.DURATION_IN_SECONDS = "1380"
+                            mutableParams.DURATION_IN_SECONDS = "${masterDuration}"
                             buildStorageCanary(false, mutableParams)
                         }
                     }
@@ -565,7 +596,9 @@ pipeline {
                     }
                     steps {
                         script {
-                            runViewerSessions("Viewer1", 55, "2")
+                            def waitMins = (params.VIEWER_WAIT_MINUTES != null && params.VIEWER_WAIT_MINUTES.toString().trim() != '') ? params.VIEWER_WAIT_MINUTES.toInteger() : 55
+                            // Viewer1 starts immediately (0 second stagger)
+                            runViewerSessions("Viewer1", waitMins, "2", 0)
                         }
                     }
                 }
@@ -575,7 +608,9 @@ pipeline {
                     }
                     steps {
                         script {
-                            runViewerSessions("Viewer2", 55, "2")
+                            def waitMins = (params.VIEWER_WAIT_MINUTES != null && params.VIEWER_WAIT_MINUTES.toString().trim() != '') ? params.VIEWER_WAIT_MINUTES.toInteger() : 55
+                            // Viewer2 starts 15 seconds after Viewer1
+                            runViewerSessions("Viewer2", waitMins, "2", 15)
                         }
                     }
                 }
@@ -593,8 +628,12 @@ pipeline {
                     }
                     steps {
                         script {
+                            def viewerWaitMin = (params.VIEWER_WAIT_MINUTES != null && params.VIEWER_WAIT_MINUTES.toString().trim() != '') ? params.VIEWER_WAIT_MINUTES.toInteger() : 55
+                            def sessionDurationSec = (params.VIEWER_SESSION_DURATION_SECONDS != null && params.VIEWER_SESSION_DURATION_SECONDS.toString().trim() != '') ? params.VIEWER_SESSION_DURATION_SECONDS.toInteger() : 600
+                            // Master duration = viewer wait + 3 sessions + 2 inter-session gaps + 10 min buffer
+                            def masterDuration = (viewerWaitMin * 60) + (3 * sessionDurationSec) + (2 * 60) + 600
                             def mutableParams = [:] + params
-                            mutableParams.DURATION_IN_SECONDS = "1380"
+                            mutableParams.DURATION_IN_SECONDS = "${masterDuration}"
                             buildStorageCanary(false, mutableParams)
                         }
                     }
@@ -605,7 +644,9 @@ pipeline {
                     }
                     steps {
                         script {
-                            runViewerSessions("Viewer1", 55, "3")
+                            def waitMins = (params.VIEWER_WAIT_MINUTES != null && params.VIEWER_WAIT_MINUTES.toString().trim() != '') ? params.VIEWER_WAIT_MINUTES.toInteger() : 55
+                            // Viewer1 starts immediately (0 second stagger)
+                            runViewerSessions("Viewer1", waitMins, "3", 0)
                         }
                     }
                 }
@@ -615,7 +656,9 @@ pipeline {
                     }
                     steps {
                         script {
-                            runViewerSessions("Viewer2", 55, "3")
+                            def waitMins = (params.VIEWER_WAIT_MINUTES != null && params.VIEWER_WAIT_MINUTES.toString().trim() != '') ? params.VIEWER_WAIT_MINUTES.toInteger() : 55
+                            // Viewer2 starts 15 seconds after Viewer1
+                            runViewerSessions("Viewer2", waitMins, "3", 15)
                         }
                     }
                 }
@@ -625,7 +668,9 @@ pipeline {
                     }
                     steps {
                         script {
-                            runViewerSessions("Viewer3", 55, "3")
+                            def waitMins = (params.VIEWER_WAIT_MINUTES != null && params.VIEWER_WAIT_MINUTES.toString().trim() != '') ? params.VIEWER_WAIT_MINUTES.toInteger() : 55
+                            // Viewer3 starts 30 seconds after Viewer1
+                            runViewerSessions("Viewer3", waitMins, "3", 30)
                         }
                     }
                 }
@@ -714,6 +759,10 @@ pipeline {
                       string(name: 'MIN_RETRY_DELAY_IN_SECONDS', value: params.MIN_RETRY_DELAY_IN_SECONDS),
                       string(name: 'GIT_URL', value: params.GIT_URL),
                       string(name: 'GIT_HASH', value: params.GIT_HASH),
+                      string(name: 'ENDPOINT', value: params.ENDPOINT),
+                      string(name: 'METRIC_SUFFIX', value: params.METRIC_SUFFIX),
+                      string(name: 'VIEWER_WAIT_MINUTES', value: params.VIEWER_WAIT_MINUTES),
+                      string(name: 'VIEWER_SESSION_DURATION_SECONDS', value: params.VIEWER_SESSION_DURATION_SECONDS),
                       booleanParam(name: 'FIRST_ITERATION', value: false)
                     ],
                     wait: false

--- a/canary/webrtc-c/scripts/chrome-headless.js
+++ b/canary/webrtc-c/scripts/chrome-headless.js
@@ -1,20 +1,42 @@
 const puppeteer = require('puppeteer');
 const { CloudWatchClient } = require('@aws-sdk/client-cloudwatch');
-const { CloudWatchMetrics } = require('./cloudwatch');
+const { CloudWatchMetrics, CloudWatchLogger } = require('./cloudwatch');
 const fs = require('fs');
 
 function log(message) {
   const timestamp = new Date().toISOString();
-  console.log(`[${timestamp}] ${message}`);
+  const formatted = `[${timestamp}] ${message}`;
+  console.log(formatted);
+  CloudWatchLogger.log(formatted);
 }
+
+// Capture unhandled errors and flush logs before dying
+process.on('unhandledRejection', async (reason) => {
+  log(`FATAL: Unhandled rejection: ${reason}`);
+  await CloudWatchLogger.shutdown();
+  process.exit(1);
+});
+
+process.on('uncaughtException', async (err) => {
+  log(`FATAL: Uncaught exception: ${err.message}\n${err.stack}`);
+  await CloudWatchLogger.shutdown();
+  process.exit(1);
+});
+
+process.on('SIGTERM', async () => {
+  log('Received SIGTERM — flushing logs before exit');
+  await CloudWatchLogger.shutdown();
+  process.exit(143);
+});
 
 class ViewerCanaryTest {
   constructor(config) {
     this.config = config;
     this.viewerId = process.env.VIEWER_ID || 'Viewer1';
     this.clientId = process.env.CLIENT_ID || `viewer-${Date.now()}`;
+    this.metricSuffix = config.metricSuffix || '';
     
-    log(`Initializing test with ${this.viewerId} (${this.clientId})`);
+    log(`Initializing test with ${this.viewerId} (${this.clientId})${this.metricSuffix ? `, metric suffix: ${this.metricSuffix}` : ''}`);
     
     this.sessionStartTime = Date.now();
     this.storageSessionJoined = false;
@@ -22,8 +44,9 @@ class ViewerCanaryTest {
     this.framesReceived = false;
     this.testCompleted = false;
     this.timerStarted = false;
-    
+
     // Comprehensive timing tracking for WebRTC connection stages
+    this.joinSSCallTime = null;
     this.offerReceivedTime = null;
     this.answerSentTime = null;
     this.firstIceCandidateReceivedTime = null;
@@ -35,17 +58,74 @@ class ViewerCanaryTest {
     this.hasReceivedFirstIceCandidate = false;
     this.hasSentFirstIceCandidate = false;
     
+    // ICE candidate type tracking
+    this.firstHostCandidateTime = null;
+    this.firstSrflxCandidateTime = null;
+    this.firstRelayCandidateTime = null;
+    this.hasGeneratedHostCandidate = false;
+    this.hasGeneratedSrflxCandidate = false;
+    this.hasGeneratedRelayCandidate = false;
+    
     // WebRTC connection retry tracking (internal viewer retries)
     this.webrtcRetryCount = 0;
     this.hadWebRTCRetries = false;
+    
+    // JoinStorageSessionAsViewer retry tracking
+    this.joinSSRetryCount = 0;
+
+    // Unexpected disconnect tracking — after peer connection was successfully established
+    this.peerConnectionEstablished = false;
+    this.unexpectedDisconnectCount = 0;
+    
+    // Storage session join failure tracking - sequence detection
+    // Failure is confirmed when these 3 logs appear consecutively:
+    // 1. [VIEWER] Error joining storage session as viewer
+    // 2. [VIEWER] Stopping VIEWER connection
+    // 3. [VIEWER] Disconnected from signaling channel
+    this.storageSessionJoinFailed = false;
+    this.viewerDisconnected = false;
+    this.failureSequenceStep = 0; // Track which step of the failure sequence we're at
     
     this.browser = null;
     this.page = null;
   }
 
   async initializeCloudWatch() {
-    const cwClient = new CloudWatchClient({ region: this.config.region || 'us-west-2' });
+    const region = this.config.region || 'us-west-2';
+    const cwClient = new CloudWatchClient({ region });
     CloudWatchMetrics.init(cwClient);
+
+    // Initialize CloudWatch Logs — uses same log group as the C master canary
+    const logGroupName = process.env.CANARY_LOG_GROUP_NAME || '';
+    const logStreamName = process.env.CANARY_LOG_STREAM_NAME ||
+      `${process.env.RUNNER_LABEL || 'StorageViewer'}-${this.viewerId}-JSViewer-${Date.now()}`;
+    await CloudWatchLogger.init(region, logGroupName, logStreamName);
+  }
+
+  // Helper to generate metric name with optional suffix
+  getMetricName(baseName) {
+    return `${baseName}_${this.viewerId}${this.metricSuffix}`;
+  }
+
+  // Helper function to extract ICE candidate type from candidate string
+  extractIceCandidateType(text) {
+    // Look for DEBUG log containing ICE candidate details
+    if (!text.includes('[DEBUG] [VIEWER] ICE candidate:')) {
+      return null;
+    }
+    
+    // Extract candidate string from the log
+    // Example: candidate:2220892825 1 udp 2122260223 192.168.1.142 55262 typ host generation 0 ufrag mnD0
+    const candidateMatch = text.match(/candidate:.*?typ\s+(\w+)/);
+    if (candidateMatch && candidateMatch[1]) {
+      const candidateType = candidateMatch[1].toLowerCase();
+      // Return standardized candidate types
+      if (candidateType === 'host') return 'host';
+      if (candidateType === 'srflx') return 'srflx';  
+      if (candidateType === 'relay') return 'relay';
+    }
+    
+    return null;
   }
 
   async createBrowser() {
@@ -57,13 +137,90 @@ class ViewerCanaryTest {
 
   setupConsoleListener(page) {
     page.on('console', async (msg) => {
-      const text = msg.text();
+      // Serialize all arguments so objects show as JSON instead of [object Object]
+      let text;
+      try {
+        const args = msg.args();
+        const parts = await Promise.all(args.map(async (arg) => {
+          try {
+            const val = await arg.jsonValue();
+            return typeof val === 'object' ? JSON.stringify(val) : String(val);
+          } catch {
+            return arg.toString();
+          }
+        }));
+        text = parts.join(' ');
+      } catch {
+        text = msg.text();
+      }
       log(`PAGE: ${text}`);
       
-      // Track SDP offer received
+      // Track when JoinStorageSessionAsViewer API is called
+      if (text.includes('[VIEWER] Joining storage session as viewer')) {
+        this.joinSSCallTime = Date.now();
+        log('JoinStorageSessionAsViewer call timestamp captured');
+      }
+
+      // Track SDP offer received — this means JoinStorageSessionAsViewer succeeded
+      // (the media server sent an SDP offer back over the signaling channel)
       if (text.includes('[VIEWER] Received SDP offer from remote')) {
         this.offerReceivedTime = Date.now();
         log('SDP offer received timestamp captured');
+
+        // Calculate and publish JoinSSCallToOfferReceived metric
+        // Measures time from calling JoinStorageSessionAsViewer to receiving SDP offer
+        if (this.joinSSCallTime && this.offerReceivedTime) {
+          const joinSSToOfferTime = this.offerReceivedTime - this.joinSSCallTime;
+          log(`JoinSSCallToOfferReceived time: ${joinSSToOfferTime}ms`);
+          
+          await CloudWatchMetrics.publishMsMetric(
+            this.getMetricName('JoinSSCallToOfferReceived'),
+            this.config.channelName,
+            joinSSToOfferTime
+          );
+        }
+
+        // Push JoinSSAsViewerAvailability = 1 (this attempt succeeded)
+        log('JoinStorageSessionAsViewer attempt succeeded — pushing availability = 1');
+        await CloudWatchMetrics.publishCountMetric(
+          this.getMetricName('JoinSSAsViewerAvailability'),
+          this.config.channelName,
+          1
+        );
+
+        // Push JoinSSAsViewerTimeout = 0 (this attempt did NOT time out)
+        // This ensures CloudWatch has data points during healthy periods,
+        // not just when timeouts occur.
+        log('JoinStorageSessionAsViewer succeeded without timeout — pushing JoinSSAsViewerTimeout = 0');
+        await CloudWatchMetrics.publishCountMetric(
+          this.getMetricName('JoinSSAsViewerTimeout'),
+          this.config.channelName,
+          0
+        );
+      }
+
+      // Track JoinStorageSessionAsViewer retry failure — each retry is a failed attempt
+      // This log means the API call did not result in an SDP offer from the media server
+      if (text.includes('Did not receive SDP offer from Media Service. Retrying...')) {
+        this.joinSSRetryCount++;
+        log(`JoinStorageSessionAsViewer attempt failed (no SDP offer) — retry count: ${this.joinSSRetryCount}, pushing availability = 0`);
+        await CloudWatchMetrics.publishCountMetric(
+          this.getMetricName('JoinSSAsViewerAvailability'),
+          this.config.channelName,
+          0
+        );
+      }
+
+      // Track JoinStorageSession HTTP timeout — the API call did not complete within 6000ms
+      // Log: "TimeoutError: Request did not complete within 6000 ms"
+      // This fires once per timed-out API call attempt, before the retry log above
+      if (text.includes('TimeoutError: Request did not complete within')) {
+        log('JoinStorageSession API call timed out — pushing JoinSSAsViewerTimeout = 1');
+        await CloudWatchMetrics.publishCountMetric(
+          this.getMetricName('JoinSSAsViewerTimeout'),
+          this.config.channelName,
+          1
+        );
       }
       
       // Track SDP answer sent and calculate offer-to-answer metric
@@ -77,7 +234,7 @@ class ViewerCanaryTest {
           log(`Offer to Answer time: ${offerToAnswerTime}ms`);
           
           await CloudWatchMetrics.publishMsMetric(
-            `OfferReceivedToAnswerSentTime_${this.viewerId}`,
+            this.getMetricName('OfferReceivedToAnswerSentTime'),
             this.config.channelName,
             offerToAnswerTime
           );
@@ -96,7 +253,7 @@ class ViewerCanaryTest {
           log(`Answer Sent to First ICE Received time: ${answerToFirstIceTime}ms`);
           
           await CloudWatchMetrics.publishMsMetric(
-            `AnswerSentToFirstIceReceivedTime_${this.viewerId}`,
+            this.getMetricName('AnswerSentToFirstIceReceivedTime'),
             this.config.channelName,
             answerToFirstIceTime
           );
@@ -115,9 +272,54 @@ class ViewerCanaryTest {
           log(`First ICE Received to First ICE Sent time: ${firstIceReceivedToSentTime}ms`);
           
           await CloudWatchMetrics.publishMsMetric(
-            `FirstIceReceivedToFirstIceSentTime_${this.viewerId}`,
+            this.getMetricName('FirstIceReceivedToFirstIceSentTime'),
             this.config.channelName,
             firstIceReceivedToSentTime
+          );
+        }
+      }
+      
+      // Track specific ICE candidate types (host, srflx, relay)
+      const candidateType = this.extractIceCandidateType(text);
+      if (candidateType && this.answerSentTime) {
+        const currentTime = Date.now();
+        
+        if (candidateType === 'host' && !this.hasGeneratedHostCandidate) {
+          this.firstHostCandidateTime = currentTime;
+          this.hasGeneratedHostCandidate = true;
+          const timeToHostCandidate = currentTime - this.answerSentTime;
+          log(`First HOST candidate generated: ${timeToHostCandidate}ms after answer sent`);
+          
+          await CloudWatchMetrics.publishMsMetric(
+            this.getMetricName('TimeToFirstHostCandidate'),
+            this.config.channelName,
+            timeToHostCandidate
+          );
+        }
+        
+        if (candidateType === 'srflx' && !this.hasGeneratedSrflxCandidate) {
+          this.firstSrflxCandidateTime = currentTime;
+          this.hasGeneratedSrflxCandidate = true;
+          const timeToSrflxCandidate = currentTime - this.answerSentTime;
+          log(`First SRFLX candidate generated: ${timeToSrflxCandidate}ms after answer sent`);
+          
+          await CloudWatchMetrics.publishMsMetric(
+            this.getMetricName('TimeToFirstSrflxCandidate'),
+            this.config.channelName,
+            timeToSrflxCandidate
+          );
+        }
+        
+        if (candidateType === 'relay' && !this.hasGeneratedRelayCandidate) {
+          this.firstRelayCandidateTime = currentTime;
+          this.hasGeneratedRelayCandidate = true;
+          const timeToRelayCandidate = currentTime - this.answerSentTime;
+          log(`First RELAY candidate generated: ${timeToRelayCandidate}ms after answer sent`);
+          
+          await CloudWatchMetrics.publishMsMetric(
+            this.getMetricName('TimeToFirstRelayCandidate'),
+            this.config.channelName,
+            timeToRelayCandidate
           );
         }
       }
@@ -133,7 +335,7 @@ class ViewerCanaryTest {
           log(`First ICE Sent to All ICE Generated time: ${firstIceSentToAllGeneratedTime}ms`);
           
           await CloudWatchMetrics.publishMsMetric(
-            `FirstIceSentToAllIceGeneratedTime_${this.viewerId}`,
+            this.getMetricName('FirstIceSentToAllIceGeneratedTime'),
             this.config.channelName,
             firstIceSentToAllGeneratedTime
           );
@@ -143,7 +345,16 @@ class ViewerCanaryTest {
       // Track peer connection establishment
       if (text.includes('[VIEWER] Connection to peer successful!')) {
         this.peerConnectionEstablishedTime = Date.now();
+        this.peerConnectionEstablished = true;
         log('Peer connection established timestamp captured');
+
+        // Push PeerConnectionAvailability = 1 (ICE candidate pair selected, connection established)
+        log('Peer connection to media server succeeded — pushing PeerConnectionAvailability = 1');
+        await CloudWatchMetrics.publishCountMetric(
+          this.getMetricName('PeerConnectionAvailability'),
+          this.config.channelName,
+          1
+        );
         
         // Calculate all-ice-generated-to-connection-established metric
         if (this.allIceCandidatesGeneratedTime && this.peerConnectionEstablishedTime) {
@@ -151,7 +362,7 @@ class ViewerCanaryTest {
           log(`All ICE Generated to Connection Established time: ${allIceToConnectionTime}ms`);
           
           await CloudWatchMetrics.publishMsMetric(
-            `AllIceGeneratedToConnectionEstablishedTime_${this.viewerId}`,
+            this.getMetricName('AllIceGeneratedToConnectionEstablishedTime'),
             this.config.channelName,
             allIceToConnectionTime
           );
@@ -163,18 +374,81 @@ class ViewerCanaryTest {
           log(`Total Connection Establishment time (Offer to Peer Connection): ${totalConnectionTime}ms`);
           
           await CloudWatchMetrics.publishMsMetric(
-            `TotalConnectionEstablishmentTime_${this.viewerId}`,
+            this.getMetricName('TotalConnectionEstablishmentTime'),
             this.config.channelName,
             totalConnectionTime
           );
         }
       }
       
-      // Track WebRTC connection retries
-      if (text.includes('[ERROR] [VIEWER] Connection failed after 30 seconds, will enter retry.')) {
+      // Track WebRTC connection retries and peer connection failure (30s timeout)
+      if (text.includes('[VIEWER] Connection failed after 30 seconds, will enter retry.')) {
         this.webrtcRetryCount++;
         this.hadWebRTCRetries = true;
         log(`WebRTC connection retry detected! Total retries: ${this.webrtcRetryCount}`);
+
+        // Push PeerConnectionAvailability = 0 (peer connection stuck in "connecting", timed out)
+        log('Peer connection timed out after 30s — pushing PeerConnectionAvailability = 0');
+        await CloudWatchMetrics.publishCountMetric(
+          this.getMetricName('PeerConnectionAvailability'),
+          this.config.channelName,
+          0
+        );
+      }
+
+      // Track peer connection state explicitly transitioning to "failed" (ICE connectivity check failed)
+      // This is mutually exclusive with the 30s timeout above — covers the case where ICE fails outright
+      if (text.includes('[VIEWER] PeerConnection state: failed')) {
+        log('Peer connection state transitioned to FAILED — pushing PeerConnectionAvailability = 0');
+        await CloudWatchMetrics.publishCountMetric(
+          this.getMetricName('PeerConnectionAvailability'),
+          this.config.channelName,
+          0
+        );
+
+        // If peer connection was previously established, this is an unexpected disconnect
+        if (this.peerConnectionEstablished) {
+          this.unexpectedDisconnectCount++;
+          log(`Unexpected disconnect detected (failed after connected)! Count: ${this.unexpectedDisconnectCount}`);
+          await CloudWatchMetrics.publishCountMetric(
+            this.getMetricName('UnexpectedDisconnect'),
+            this.config.channelName,
+            1
+          );
+        }
+      }
+
+      // Track peer connection state transitioning to "disconnected" after being connected
+      // This indicates ICE connectivity was lost (e.g., network issue, media server dropped)
+      if (text.includes('[VIEWER] PeerConnection state: disconnected') && this.peerConnectionEstablished) {
+        this.unexpectedDisconnectCount++;
+        log(`Unexpected disconnect detected (disconnected after connected)! Count: ${this.unexpectedDisconnectCount}`);
+        await CloudWatchMetrics.publishCountMetric(
+          this.getMetricName('UnexpectedDisconnect'),
+          this.config.channelName,
+          1
+        );
+      }
+      
+      // Detect storage session join error (single failure or retry failure)
+      if (text.includes('[VIEWER] Error joining storage session as viewer')) {
+        log('Storage session join error detected!');
+        this.storageSessionJoinFailed = true;
+        this.storageSessionJoined = false;
+      }
+      
+      // Detect storage session join failure after all retries exhausted
+      if (text.includes('Stopping the application after 5 failed attempts to connect to the storage session')) {
+        log('Storage session join FAILED after 5 retry attempts!');
+        this.storageSessionJoinFailed = true;
+        this.storageSessionJoined = false;
+      }
+      
+      // Detect viewer disconnection (signals end of failed session)
+      if (text.includes('[VIEWER] Stopping VIEWER connection') || 
+          text.includes('[VIEWER] Disconnected from signaling channel')) {
+        log('Viewer disconnection detected!');
+        this.viewerDisconnected = true;
       }
       
       if (text.includes('Successfully joined the storage session')) {
@@ -189,10 +463,22 @@ class ViewerCanaryTest {
         
         const joinTime = Date.now() - this.sessionStartTime;
         await CloudWatchMetrics.publishMsMetric(
-          `JoinSSAsViewerTime_${this.viewerId}`,
+          this.getMetricName('JoinSSAsViewerTime'),
           this.config.channelName,
           joinTime
         );
+
+        // Publish JoinSSCallToSessionJoined metric — time from calling
+        // JoinStorageSessionAsViewer to successfully joining the storage session
+        if (this.joinSSCallTime) {
+          const joinSSCallToSessionJoined = Date.now() - this.joinSSCallTime;
+          log(`JoinSSCallToSessionJoined time: ${joinSSCallToSessionJoined}ms`);
+          await CloudWatchMetrics.publishMsMetric(
+            this.getMetricName('JoinSSCallToSessionJoined'),
+            this.config.channelName,
+            joinSSCallToSessionJoined
+          );
+        }
       }
     });
   }
@@ -213,6 +499,7 @@ class ViewerCanaryTest {
       sendVideo: this.config.sendVideo || 'false',
       sendAudio: this.config.sendAudio || 'false',
       useTrickleICE: 'true',
+      endpoint: this.config.endpoint || '',
     });
     
     // Add forceTURN parameter if configured
@@ -266,17 +553,34 @@ class ViewerCanaryTest {
     throw new Error('Viewer failed to start within 60 seconds');
   }
 
-  async waitForStorageSession() {
-    log('Waiting for storage session to be joined...');
-    const sessionTimeout = 180000;
+  async waitForStorageSessionOrFailure() {
+    log('Waiting for storage session to be joined or failure...');
     
-    while (!this.storageSessionJoined && (Date.now() - this.sessionStartTime) < sessionTimeout) {
+    // Wait until either:
+    // 1. Storage session is successfully joined
+    // 2. Storage session join failed AND viewer disconnected (failure complete)
+    // 3. Hard timeout reached
+    const hardTimeout = this.config.duration * 1000;
+    
+    while ((Date.now() - this.sessionStartTime) < hardTimeout) {
+      // Success case: storage session joined
+      if (this.storageSessionJoined) {
+        log('Storage session joined successfully!');
+        return { success: true };
+      }
+      
+      // Failure case: join failed and viewer disconnected
+      if (this.storageSessionJoinFailed && this.viewerDisconnected) {
+        log('Storage session join failed and viewer disconnected - failure complete');
+        return { success: false, reason: 'join_failed' };
+      }
+      
       await new Promise(resolve => setTimeout(resolve, 1000));
     }
     
-    if (!this.storageSessionJoined) {
-      throw new Error('Storage session not joined within 180 seconds');
-    }
+    // Timeout reached without success or complete failure
+    log('Timeout reached waiting for storage session');
+    return { success: false, reason: 'timeout' };
   }
 
   async getFrameStats(page) {
@@ -357,7 +661,7 @@ class ViewerCanaryTest {
     
     const frameDetectionTime = Date.now() - this.sessionStartTime;
     await CloudWatchMetrics.publishMsMetric(
-      `TimeToFirstFrame_${this.viewerId}`,
+      this.getMetricName('TimeToFirstFrame'),
       this.config.channelName,
       frameDetectionTime
     );
@@ -370,10 +674,11 @@ class ViewerCanaryTest {
     
     // Start timer immediately since we already joined the storage session
     this.timerStarted = true;
-    log('Storage session joined, running test for 45 seconds...');
+    const monitorDurationMs = 180000; // 3 minutes
+    log(`Storage session joined, monitoring connection for ${monitorDurationMs / 1000} seconds...`);
     setTimeout(() => {
       this.testCompleted = true;
-    }, 45000);
+    }, monitorDurationMs);
     
     let lastStatusLog = 0;
     const statusLogInterval = 10000;
@@ -417,19 +722,35 @@ class ViewerCanaryTest {
     // Publish success rate metric (100% for success, 0% for failure)
     const successRate = this.storageSessionJoined ? 100 : 0;
     await CloudWatchMetrics.publishPercentageMetric(
-      `StorageSessionSuccessRate_${this.viewerId}`,
+      this.getMetricName('StorageSessionSuccessRate'),
       this.config.channelName,
       successRate
     );
     
     // Publish WebRTC connection retry count metric
     await CloudWatchMetrics.publishCountMetric(
-      `WebRTCConnectionRetryCount_${this.viewerId}`,
+      this.getMetricName('WebRTCConnectionRetryCount'),
       this.config.channelName,
       this.webrtcRetryCount
     );
     
     log(`WebRTC Connection Retry Summary: Total retries: ${this.webrtcRetryCount}, Had retries: ${this.hadWebRTCRetries}`);
+    
+    // Publish JoinStorageSessionAsViewer retry count (no SDP offer received, had to retry)
+    await CloudWatchMetrics.publishCountMetric(
+      this.getMetricName('JoinSSAsViewerRetryCount'),
+      this.config.channelName,
+      this.joinSSRetryCount
+    );
+    log(`JoinSSAsViewer Retry Summary: Total retries: ${this.joinSSRetryCount}`);
+    
+    // Publish unexpected disconnect count (0 means stable connection throughout monitoring)
+    await CloudWatchMetrics.publishCountMetric(
+      this.getMetricName('UnexpectedDisconnectCount'),
+      this.config.channelName,
+      this.unexpectedDisconnectCount
+    );
+    log(`Unexpected Disconnect Summary: Total disconnects after connection: ${this.unexpectedDisconnectCount}`);
     
     // Success is based on storage session joining, not frame reception
     const success = this.storageSessionJoined;
@@ -562,10 +883,16 @@ async function runViewerCanary(config) {
         
         await test.waitForViewerStart(test.page);
         
-        await test.waitForStorageSession();
+        // Wait for storage session join or failure
+        const sessionResult = await test.waitForStorageSessionOrFailure();
         
-        // Monitor the viewer
-        await test.monitorConnection(test.page);
+        if (sessionResult.success) {
+          // Success: monitor connection briefly then complete
+          await test.monitorConnection(test.page);
+        } else {
+          // Failure: session result already captured, just log
+          log(`Storage session failed: ${sessionResult.reason}`);
+        }
         
         cleanupCompleted = true; // Mark cleanup as not needed (normal completion)
         return await test.getTestResults();
@@ -598,10 +925,14 @@ runViewerCanary({
   duration: parseInt(process.env.TEST_DURATION) || 360,
   saveFrames: process.env.SAVE_FRAMES === 'true',
   clientId: process.env.CLIENT_ID || `test-viewer-${Date.now()}`,
-  forceTURN: process.env.FORCE_TURN === 'true'
-}).then(result => {
+  forceTURN: process.env.FORCE_TURN === 'true',
+  endpoint: process.env.ENDPOINT || '',
+  metricSuffix: process.env.METRIC_SUFFIX || ''
+}).then(async (result) => {
+  await CloudWatchLogger.shutdown();
   process.exit(result.success ? 0 : 1);
-}).catch(error => {
+}).catch(async (error) => {
   log(`Test failed with error: ${error.message}`);
+  await CloudWatchLogger.shutdown();
   process.exit(1);
 });

--- a/canary/webrtc-c/scripts/cloudwatch.js
+++ b/canary/webrtc-c/scripts/cloudwatch.js
@@ -1,4 +1,5 @@
 const { CloudWatchClient, PutMetricDataCommand } = require("@aws-sdk/client-cloudwatch");
+const { CloudWatchLogsClient, CreateLogGroupCommand, CreateLogStreamCommand, PutLogEventsCommand } = require("@aws-sdk/client-cloudwatch-logs");
 
 class CloudWatchMetrics {
     static cwClient;
@@ -155,4 +156,103 @@ class CloudWatchMetrics {
     }
 }
 
-module.exports = { CloudWatchMetrics };
+class CloudWatchLogger {
+    static logsClient = null;
+    static logGroupName = null;
+    static logStreamName = null;
+    static logBuffer = [];
+    static flushInterval = null;
+    static initialized = false;
+    static flushing = false;
+
+    static async init(region, logGroupName, logStreamName) {
+        if (!logGroupName || !logStreamName) {
+            console.log('CloudWatchLogger: No log group/stream configured, logging to stdout only');
+            return;
+        }
+
+        this.logsClient = new CloudWatchLogsClient({ region });
+        this.logGroupName = logGroupName;
+        this.logStreamName = logStreamName;
+
+        // Ensure log group exists
+        try {
+            await this.logsClient.send(new CreateLogGroupCommand({
+                logGroupName: this.logGroupName,
+            }));
+            console.log(`CloudWatchLogger: Created log group ${this.logGroupName}`);
+        } catch (e) {
+            if (e.name === 'ResourceAlreadyExistsException') {
+                // Expected — log group already exists
+            } else {
+                console.error(`CloudWatchLogger: Failed to create log group: ${e.message}`);
+                return;
+            }
+        }
+
+        // Create log stream
+        try {
+            await this.logsClient.send(new CreateLogStreamCommand({
+                logGroupName: this.logGroupName,
+                logStreamName: this.logStreamName,
+            }));
+            console.log(`CloudWatchLogger: Created log stream ${this.logStreamName}`);
+        } catch (e) {
+            if (e.name === 'ResourceAlreadyExistsException') {
+                // Expected — log stream already exists
+            } else {
+                console.error(`CloudWatchLogger: Failed to create log stream: ${e.message}`);
+                return;
+            }
+        }
+
+        // Flush every 5 seconds
+        this.flushInterval = setInterval(() => this.flush(), 5000);
+        this.initialized = true;
+        console.log(`CloudWatchLogger: Initialized — group=${this.logGroupName}, stream=${this.logStreamName}`);
+    }
+
+    static log(message) {
+        if (!this.initialized) return;
+        this.logBuffer.push({
+            message: typeof message === 'string' ? message : JSON.stringify(message),
+            timestamp: Date.now(),
+        });
+    }
+
+    static async flush() {
+        if (!this.initialized || this.logBuffer.length === 0 || this.flushing) return;
+
+        this.flushing = true;
+        const events = this.logBuffer.splice(0, this.logBuffer.length);
+
+        // PutLogEvents requires events sorted by timestamp
+        events.sort((a, b) => a.timestamp - b.timestamp);
+
+        try {
+            await this.logsClient.send(new PutLogEventsCommand({
+                logGroupName: this.logGroupName,
+                logStreamName: this.logStreamName,
+                logEvents: events,
+            }));
+        } catch (e) {
+            console.error(`CloudWatchLogger: Failed to push ${events.length} log events: ${e.message}`);
+            // Put events back at the front of the buffer for retry
+            this.logBuffer.unshift(...events);
+        } finally {
+            this.flushing = false;
+        }
+    }
+
+    static async shutdown() {
+        if (this.flushInterval) {
+            clearInterval(this.flushInterval);
+            this.flushInterval = null;
+        }
+        // Final flush to ensure all buffered logs are sent
+        await this.flush();
+        console.log('CloudWatchLogger: Shutdown complete');
+    }
+}
+
+module.exports = { CloudWatchMetrics, CloudWatchLogger };

--- a/canary/webrtc-c/scripts/package.json
+++ b/canary/webrtc-c/scripts/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "@aws-sdk/client-cloudwatch": "^3.970.0",
+    "@aws-sdk/client-cloudwatch-logs": "^3.970.0",
+    "puppeteer": "^24.35.0"
+  }
+}

--- a/canary/webrtc-c/scripts/setup-storage-viewer.sh
+++ b/canary/webrtc-c/scripts/setup-storage-viewer.sh
@@ -29,15 +29,46 @@ echo "npm verified: $(npm --version)"
 
 cd ./canary/webrtc-c/scripts || { echo "ERROR: Failed to change directory to ./canary/webrtc-c/scripts"; exit 1; }
 
-# Install Node.js dependencies if not exists
-if [ ! -d "node_modules" ]; then
-    npm install puppeteer @aws-sdk/client-cloudwatch || { echo "ERROR: Failed to install Node.js dependencies"; exit 1; }
+npm install || { echo "ERROR: Failed to install Node.js dependencies"; exit 1; }
+
+# Verify Puppeteer can find Chrome. If the cached version doesn't match what
+# Puppeteer expects (e.g., after a Puppeteer upgrade), force-install the correct one.
+CHROME_PATH=$(node -e "try { console.log(require('puppeteer').executablePath()) } catch(e) { console.log('') }" 2>/dev/null)
+if [ -z "$CHROME_PATH" ] || [ ! -f "$CHROME_PATH" ]; then
+    echo "Puppeteer Chrome not found or version mismatch, installing correct version..."
+    # Clear stale cache to avoid disk bloat
+    rm -rf "$HOME/.cache/puppeteer/chrome" 2>/dev/null || true
+    npx puppeteer browsers install chrome || { echo "ERROR: Failed to install Chrome for Puppeteer"; exit 1; }
+    echo "Chrome installed successfully"
+else
+    echo "Puppeteer Chrome verified at: $CHROME_PATH"
 fi
 
 # Set environment variables for the test
 export CANARY_CHANNEL_NAME="${JOB_NAME}-${RUNNER_LABEL}"
 export AWS_REGION="${AWS_DEFAULT_REGION}"
 export TEST_DURATION="${DURATION_IN_SECONDS}"
+
+# CloudWatch Logs configuration — JS viewer logs go to a separate log group
+export CANARY_LOG_GROUP_NAME="JSSDK"
+export CANARY_LOG_STREAM_NAME="${RUNNER_LABEL}-${VIEWER_ID:-Viewer}-JSViewer-$(date +%s%3N)"
+
+# Debug: Show what ENDPOINT value we received
+echo "DEBUG: ENDPOINT env var = '${ENDPOINT}'"
+
+# Set endpoint if provided (defaults to empty)
+if [ -n "${ENDPOINT}" ]; then
+    export ENDPOINT="${ENDPOINT}"
+    echo "Using custom endpoint: ${ENDPOINT}"
+else
+    echo "No custom endpoint provided, using default"
+fi
+
+# Set metric suffix if provided (defaults to empty)
+if [ -n "${METRIC_SUFFIX}" ]; then
+    export METRIC_SUFFIX="${METRIC_SUFFIX}"
+    echo "Using metric suffix: ${METRIC_SUFFIX}"
+fi
 
 # Run storage viewer test
 node chrome-headless.js || { echo "ERROR: Chrome headless test failed"; exit 1; }

--- a/canary/webrtc-c/src/CloudwatchMonitoring.cpp
+++ b/canary/webrtc-c/src/CloudwatchMonitoring.cpp
@@ -454,4 +454,70 @@ VOID CloudwatchMonitoring::pushRetryCount(UINT32 retryCount)
     this->push(currentRetryCountDatum);
 }
 
+VOID CloudwatchMonitoring::pushJoinStorageSessionAvailability(DOUBLE availability)
+{
+    MetricDatum datum;
+
+    datum.SetMetricName("JoinStorageSessionAvailability");
+    datum.SetValue(availability);
+    datum.SetUnit(Aws::CloudWatch::Model::StandardUnit::None);
+
+    this->push(datum);
+}
+
+VOID CloudwatchMonitoring::pushPeerConnectionAvailability(DOUBLE availability)
+{
+    MetricDatum datum;
+
+    datum.SetMetricName("PeerConnectionAvailability");
+    datum.SetValue(availability);
+    datum.SetUnit(Aws::CloudWatch::Model::StandardUnit::None);
+
+    this->push(datum);
+}
+
+VOID CloudwatchMonitoring::pushCMasterRetryCount(UINT32 retryCount)
+{
+    MetricDatum datum;
+
+    datum.SetMetricName("CMasterRetryCount");
+    datum.SetValue(retryCount);
+    datum.SetUnit(Aws::CloudWatch::Model::StandardUnit::Count);
+
+    this->push(datum);
+}
+
+VOID CloudwatchMonitoring::pushJoinSSTimeout(UINT32 timeoutCount)
+{
+    MetricDatum datum;
+
+    datum.SetMetricName("JoinSSTimeout");
+    datum.SetValue(timeoutCount);
+    datum.SetUnit(Aws::CloudWatch::Model::StandardUnit::Count);
+
+    this->push(datum);
+}
+
+VOID CloudwatchMonitoring::pushJoinSSCallToSessionJoined(UINT64 duration, Aws::CloudWatch::Model::StandardUnit unit)
+{
+    MetricDatum datum;
+
+    datum.SetMetricName("JoinSSCallToSessionJoined");
+    datum.SetValue(duration);
+    datum.SetUnit(unit);
+
+    this->push(datum);
+}
+
+VOID CloudwatchMonitoring::pushCMasterUnexpectedDisconnection(UINT32 disconnectionCount)
+{
+    MetricDatum datum;
+
+    datum.SetMetricName("CMasterUnexpectedDisconnection");
+    datum.SetValue(disconnectionCount);
+    datum.SetUnit(Aws::CloudWatch::Model::StandardUnit::Count);
+
+    this->push(datum);
+}
+
 } // namespace Canary

--- a/canary/webrtc-c/src/CloudwatchMonitoring.h
+++ b/canary/webrtc-c/src/CloudwatchMonitoring.h
@@ -25,6 +25,12 @@ class CloudwatchMonitoring {
 
     VOID pushStorageDisconnectToFrameSentTime(UINT64, Aws::CloudWatch::Model::StandardUnit);
     VOID pushJoinSessionTime(UINT64, Aws::CloudWatch::Model::StandardUnit);
+    VOID pushJoinStorageSessionAvailability(DOUBLE);
+    VOID pushPeerConnectionAvailability(DOUBLE);
+    VOID pushCMasterRetryCount(UINT32);
+    VOID pushJoinSSTimeout(UINT32);
+    VOID pushJoinSSCallToSessionJoined(UINT64, Aws::CloudWatch::Model::StandardUnit);
+    VOID pushCMasterUnexpectedDisconnection(UINT32);
 
   private:
     Dimension channelDimension;

--- a/canary/webrtc-c/src/Include.h
+++ b/canary/webrtc-c/src/Include.h
@@ -73,6 +73,7 @@
 #define IOT_CORE_PRIVATE_KEY_ENV_VAR                     "AWS_IOT_CORE_PRIVATE_KEY"
 #define IOT_CORE_ROLE_ALIAS_ENV_VAR                      "AWS_IOT_CORE_ROLE_ALIAS"
 #define IOT_CORE_THING_NAME_ENV_VAR                      "AWS_IOT_CORE_THING_NAME"
+#define CONTROL_PLANE_URI_ENV_VAR                        "CONTROL_PLANE_URI"
 #define STORAGE_CANARY_FIRST_FRAME_TS_FILE_ENV_VAR       "STORAGE_CANARY_FIRST_FRAME_TS_FILE"
 
 #define CANARY_DEFAULT_LABEL                       "ScaryTestLabel"

--- a/canary/webrtc-c/src/media-server-storage/Common.cpp
+++ b/canary/webrtc-c/src/media-server-storage/Common.cpp
@@ -4,6 +4,20 @@
 
 PSampleConfiguration gSampleConfiguration = NULL;
 
+// Counter for JoinStorageSession timeouts (STATUS_OPERATION_TIMED_OUT = 0x0000000f).
+// Incremented each time signalingClientConnectSync() times out during the JoinStorageSession flow.
+// The signalingClientConnectSync() call includes WebSocket connect, JoinStorageSession API call,
+// and waiting for SDP offer.
+UINT32 gJoinSSTimeoutCount = 0;
+
+// Counter for unexpected peer connection disconnections.
+// Only incremented when RTC_PEER_CONNECTION_STATE_FAILED or RTC_PEER_CONNECTION_STATE_DISCONNECTED
+// fires AFTER the peer connection was already in CONNECTED state.
+// CLOSED is NOT counted (it's the expected ~1hr backend session termination).
+// If FAILED/DISCONNECTED fires before ever reaching CONNECTED, it is NOT counted
+// (that's a normal connection failure, not an unexpected disconnection).
+UINT32 gCMasterUnexpectedDisconnectionCount = 0;
+
 // To ensure we don't try to send outbound RTP metrics during freeing of session.
 MUTEX sessionCoummunalLock = MUTEX_CREATE(FALSE);
 
@@ -283,6 +297,16 @@ VOID onConnectionStateChange(UINT64 customData, RTC_PEER_CONNECTION_STATE newSta
             if (STATUS_FAILED(retStatus = logSelectedIceCandidatesInformation(pSampleStreamingSession))) {
                 DLOGW("Failed to get information about selected Ice candidates: 0x%08x", retStatus);
             }
+
+            DLOGI("[Canary] Peer connection established successfully — pushing PeerConnectionAvailability = 1");
+            Canary::Cloudwatch::getInstance().monitoring.pushPeerConnectionAvailability(1.0);
+
+            // Push JoinSSCallToSessionJoined metric — time from signalingClientConnectSync() call to peer connection established
+            if (pSampleConfiguration->joinSSCallStartTime != 0) {
+                UINT64 joinSSCallToSessionJoined = (GETTIME() - pSampleConfiguration->joinSSCallStartTime) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+                DLOGI("[Canary] JoinSSCallToSessionJoined: %" PRIu64 " ms", joinSSCallToSessionJoined);
+                Canary::Cloudwatch::getInstance().monitoring.pushJoinSSCallToSessionJoined(joinSSCallToSessionJoined, Aws::CloudWatch::Model::StandardUnit::Milliseconds);
+            }
             
             pSampleStreamingSession->canaryOutgoingRTPMetricsContext.prevTs = GETTIME();
             pSampleStreamingSession->canaryOutgoingRTPMetricsContext.prevFramesDiscardedOnSend = 0;
@@ -292,10 +316,23 @@ VOID onConnectionStateChange(UINT64 customData, RTC_PEER_CONNECTION_STATE newSta
             CHK_STATUS(initMetricsTimers(pSampleStreamingSession));
             break;
         case RTC_PEER_CONNECTION_STATE_FAILED:
+            DLOGE("[Canary] Peer connection FAILED — pushing PeerConnectionAvailability = 0");
+            Canary::Cloudwatch::getInstance().monitoring.pushPeerConnectionAvailability(0.0);
             // explicit fallthrough
         case RTC_PEER_CONNECTION_STATE_CLOSED:
             // explicit fallthrough
         case RTC_PEER_CONNECTION_STATE_DISCONNECTED:
+            // Count as unexpected disconnection if we were previously CONNECTED and the state
+            // is FAILED or DISCONNECTED. CLOSED is expected (backend terminates storage sessions
+            // after ~1 hour), so we don't count it.
+            // DISCONNECTED also terminates the session in this code (sets terminateFlag = TRUE),
+            // so it's effectively an unexpected termination if we were connected.
+            if ((newState == RTC_PEER_CONNECTION_STATE_FAILED || newState == RTC_PEER_CONNECTION_STATE_DISCONNECTED) &&
+                ATOMIC_LOAD_BOOL(&pSampleConfiguration->connected)) {
+                gCMasterUnexpectedDisconnectionCount++;
+                DLOGE("[Canary] Unexpected disconnection detected (was CONNECTED, now state %u). Count: %u",
+                      newState, gCMasterUnexpectedDisconnectionCount);
+            }
             DLOGD("p2p connection disconnected");
             ATOMIC_STORE_BOOL(&pSampleStreamingSession->terminateFlag, TRUE);
             CVAR_BROADCAST(pSampleConfiguration->cvar);
@@ -1121,8 +1158,22 @@ STATUS initSignaling(PSampleConfiguration pSampleConfiguration, PCHAR clientId)
 #ifdef ENABLE_DATA_CHANNEL
     pSampleConfiguration->onDataChannel = onDataChannel;
 #endif
-
-    CHK_STATUS(signalingClientConnectSync(pSampleConfiguration->signalingClientHandle));
+    pSampleConfiguration->joinSSCallStartTime = GETTIME();
+    retStatus = signalingClientConnectSync(pSampleConfiguration->signalingClientHandle);
+    if (pSampleConfiguration->channelInfo.useMediaStorage) {
+        if (STATUS_SUCCEEDED(retStatus)) {
+            DLOGI("[KVS Master] JoinStorageSession call succeeded (initial)");
+            Canary::Cloudwatch::getInstance().monitoring.pushJoinStorageSessionAvailability(1.0);
+        } else {
+            DLOGE("[KVS Master] JoinStorageSession call failed (initial) with 0x%08x", retStatus);
+            Canary::Cloudwatch::getInstance().monitoring.pushJoinStorageSessionAvailability(0.0);
+            if (retStatus == STATUS_OPERATION_TIMED_OUT) {
+                gJoinSSTimeoutCount++;
+                DLOGE("[KVS Master] JoinStorageSession timed out (initial). Timeout count: %u", gJoinSSTimeoutCount);
+            }
+        }
+    }
+    CHK_STATUS(retStatus);
 
     signalingClientGetMetrics(pSampleConfiguration->signalingClientHandle, &signalingClientMetrics);
 
@@ -1511,7 +1562,20 @@ STATUS sessionCleanupWait(PSampleConfiguration pSampleConfiguration)
             // offer.  The signalingClientConnectSync call will result in a JoinSession API call being made.
             CHK_STATUS(signalingClientDisconnectSync(pSampleConfiguration->signalingClientHandle));
             CHK_STATUS(signalingClientFetchSync(pSampleConfiguration->signalingClientHandle));
-            CHK_STATUS(signalingClientConnectSync(pSampleConfiguration->signalingClientHandle));
+            pSampleConfiguration->joinSSCallStartTime = GETTIME();
+            retStatus = signalingClientConnectSync(pSampleConfiguration->signalingClientHandle);
+            if (STATUS_SUCCEEDED(retStatus)) {
+                DLOGI("[KVS Master] JoinStorageSession call succeeded (reconnect)");
+                Canary::Cloudwatch::getInstance().monitoring.pushJoinStorageSessionAvailability(1.0);
+            } else {
+                DLOGE("[KVS Master] JoinStorageSession call failed (reconnect) with 0x%08x", retStatus);
+                Canary::Cloudwatch::getInstance().monitoring.pushJoinStorageSessionAvailability(0.0);
+                if (retStatus == STATUS_OPERATION_TIMED_OUT) {
+                    gJoinSSTimeoutCount++;
+                    DLOGE("[KVS Master] JoinStorageSession timed out (reconnect). Timeout count: %u", gJoinSSTimeoutCount);
+                }
+            }
+            CHK_STATUS(retStatus);
             sessionFreed = FALSE;
         }
 

--- a/canary/webrtc-c/src/media-server-storage/Samples.h
+++ b/canary/webrtc-c/src/media-server-storage/Samples.h
@@ -138,6 +138,7 @@ typedef struct {
 
     std::atomic<UINT64> storageDisconnectedTime;
     UINT64 offerReceiveTimestamp;
+    UINT64 joinSSCallStartTime;
     UINT64 sampleDuration;
     PCHAR fristFrameSentTSFileName;
     UINT64 startTime;

--- a/canary/webrtc-c/src/media-server-storage/kvsWebRTCClientMaster.cpp
+++ b/canary/webrtc-c/src/media-server-storage/kvsWebRTCClientMaster.cpp
@@ -3,6 +3,8 @@
 
 
 extern PSampleConfiguration gSampleConfiguration;
+extern UINT32 gJoinSSTimeoutCount;
+extern UINT32 gCMasterUnexpectedDisconnectionCount;
 
 INT32 main(INT32 argc, CHAR* argv[])
 {
@@ -10,6 +12,8 @@ INT32 main(INT32 argc, CHAR* argv[])
     UINT32 frameSize;
     PSampleConfiguration pSampleConfiguration = NULL;
     PCHAR pChannelName;
+    PCHAR pControlPlaneUri = NULL;
+    CHAR controlPlaneUrl[MAX_CONTROL_PLANE_URI_CHAR_LEN];
     SignalingClientMetrics signalingClientMetrics;
     signalingClientMetrics.version = SIGNALING_CLIENT_METRICS_CURRENT_VERSION;
 
@@ -52,6 +56,19 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     // Set sample to use storage mode
     pSampleConfiguration->channelInfo.useMediaStorage = TRUE;
+
+    // Set custom control plane URL if CONTROL_PLANE_URI is provided (e.g., for gamma testing).
+    // This overrides the default control plane URL so that all control plane API calls
+    // (DescribeSignalingChannel, GetSignalingChannelEndpoint, etc.) go to the custom endpoint.
+    // JoinStorageSession will then use the data plane endpoint returned by GetSignalingChannelEndpoint.
+    pControlPlaneUri = GETENV(CONTROL_PLANE_URI_ENV_VAR);
+    if (pControlPlaneUri != NULL && pControlPlaneUri[0] != '\0') {
+        SNPRINTF(controlPlaneUrl, MAX_CONTROL_PLANE_URI_CHAR_LEN, "%s", pControlPlaneUri);
+        pSampleConfiguration->channelInfo.pControlPlaneUrl = controlPlaneUrl;
+        DLOGI("[KVS Master] Using custom control plane URL: %s", controlPlaneUrl);
+    } else {
+        DLOGI("[KVS Master] No custom control plane URL set, using default");
+    }
 
     // Initialize storage disconnected timestamp
     pSampleConfiguration->storageDisconnectedTime = 0;
@@ -96,7 +113,30 @@ CleanUp:
     DLOGI("Exiting with 0x%08x", retStatus);
     if (initialized) {
         Canary::Cloudwatch::getInstance().monitoring.pushExitStatus(retStatus);
+
+        // Push cumulative JoinStorageSession timeout count (0 if no timeouts occurred)
+        DLOGI("[KVS Master] Pushing JoinSSTimeout: %u", gJoinSSTimeoutCount);
+        Canary::Cloudwatch::getInstance().monitoring.pushJoinSSTimeout(gJoinSSTimeoutCount);
+
+        // Push cumulative unexpected disconnection count (0 if none occurred)
+        DLOGI("[KVS Master] Pushing CMasterUnexpectedDisconnection: %u", gCMasterUnexpectedDisconnectionCount);
+        Canary::Cloudwatch::getInstance().monitoring.pushCMasterUnexpectedDisconnection(gCMasterUnexpectedDisconnectionCount);
     }
+
+    // Fetch signaling client metrics before CloudWatch deinit so we can push CMasterRetryCount
+    if (pSampleConfiguration != NULL) {
+        STATUS metricsStatus = signalingClientGetMetrics(pSampleConfiguration->signalingClientHandle, &signalingClientMetrics);
+        if (metricsStatus == STATUS_SUCCESS) {
+            logSignalingClientStats(&signalingClientMetrics);
+            if (initialized) {
+                DLOGI("[KVS Master] Pushing CMasterRetryCount: %d", signalingClientMetrics.signalingClientStats.apiCallRetryCount);
+                Canary::Cloudwatch::getInstance().monitoring.pushCMasterRetryCount(signalingClientMetrics.signalingClientStats.apiCallRetryCount);
+            }
+        } else {
+            DLOGE("[KVS Master] signalingClientGetMetrics() operation returned status code: 0x%08x", metricsStatus);
+        }
+    }
+
     Canary::Cloudwatch::deinit();
 
     DLOGI("[KVS Master] Cleaning up....");
@@ -106,13 +146,6 @@ CleanUp:
 
         if (pSampleConfiguration->mediaSenderTid != INVALID_TID_VALUE) {
             THREAD_JOIN(pSampleConfiguration->mediaSenderTid, NULL);
-        }
-
-        retStatus = signalingClientGetMetrics(pSampleConfiguration->signalingClientHandle, &signalingClientMetrics);
-        if (retStatus == STATUS_SUCCESS) {
-            logSignalingClientStats(&signalingClientMetrics);
-        } else {
-            DLOGE("[KVS Master] signalingClientGetMetrics() operation returned status code: 0x%08x", retStatus);
         }
         retStatus = freeSignalingClient(&pSampleConfiguration->signalingClientHandle);
         if (retStatus != STATUS_SUCCESS) {


### PR DESCRIPTION
## Phase 3: Gamma Expansion

_What is changed_

- Added dedicated gamma testing infrastructure (`gamma_seed.groovy`, `gamma_orchestrator.groovy`, `gamma_runner.groovy`) completely independent from production canary jobs
- Added custom control plane endpoint support so the C Master and JS Viewer can target gamma instead of prod
- Added `METRIC_SUFFIX` parameter to separate gamma metrics from prod in CloudWatch
- Added configurable `VIEWER_WAIT_MINUTES` and dynamic master duration (no more hardcoded waits)
- Added `RESCHEDULE` parameter to allow one-off debugging runs without auto-looping
- Reworked `ViewerConnectionSuccessRate` to single-session, attempt-based calculation
- Added JS viewer log streaming to CloudWatch Logs for remote debugging
- Added 9 new CloudWatch metrics for availability, retry, and latency observability
- Updated prod orchestrator and runner to include gamma-specific job parameters

_Why it's changed_

Running canaries only in prod means we detect regressions after they've already shipped. By expanding to gamma:
- We validate service deployments before they reach production — when the service team deploys a new build to gamma, the canary catches availability drops or latency regressions in that environment first
- We can point the canary at a custom SDK branch and compare metrics side-by-side with prod to confirm improvements landed as expected
- We get a pre-production testing environment that mirrors prod behavior (NAT-restrictive instances force TURN relay, same viewer/master topology)

The new metrics (PeerConnectionAvailability, JoinStorageSessionAvailability, etc.) fill observability gaps where previously we had no signal for specific failure modes like session join failures, timeout conditions, or unexpected disconnections.

_How it's changed_

- **New files**: `gamma_seed.groovy` (creates Jenkins jobs), `gamma_orchestrator.groovy` (triggers gamma test scenarios), `gamma_runner.groovy` (executes tests against gamma endpoint), `scripts/package.json` (viewer Node.js dependencies)
- **`runner.groovy`**: Added `FORCE_TURN`, `USE_IOT`, `ENDPOINT`, `METRIC_SUFFIX`, `VIEWER_WAIT_MINUTES`, `RESCHEDULE` parameters; added viewer log push to CloudWatch; reworked reschedule to `post{always}`
- **`orchestrator.groovy`**: Added `StorageWithViewer` multi-viewer job definitions with gamma node labels
- **`chrome-headless.js`**: Added `JoinSSCallToOfferReceived`, `JoinSSAsViewerRetryCount`, `JoinSSAsViewerAvailability`, `JoinSSAsViewerTimeout`, `PeerConnectionAvailability`, `UnexpectedDisconnect` metric emissions; added CloudWatch Logs integration; added configurable endpoint and metric suffix
- **`cloudwatch.js`**: Added `publishCountMetric()`, `publishPercentageMetric()`, CloudWatch Logs helper functions
- **`setup-storage-viewer.sh`**: Added Node.js retry logic and conditional install
- **C++ source** (`CloudwatchMonitoring.cpp/h`, `Common.cpp`, `kvsWebRTCClientMaster.cpp`): Added `JoinStorageSessionAvailability`, `PeerConnectionAvailability`, `CMasterRetryCount`, `UnexpectedDisconnectCount`, `JoinSSCallToSessionJoined` metric push functions; added custom endpoint URL pass-through

**New metrics:**

| Metric | Type | Description |
|--------|------|-------------|
| `JoinStorageSessionAvailability` | Count (0/1) | 1 if JoinStorageSession API succeeded |
| `JoinSSAsViewerAvailability` | Count (0/1) | 1 if SDP offer received from media server |
| `PeerConnectionAvailability` | Count (0/1) | 1 on CONNECTED, 0 on FAILED |
| `CMasterRetryCount` | Count | C Master reconnection attempts |
| `JoinSSAsViewerTimeout` | Count (0/1) | 1 if API call timed out |
| `JoinSSAsViewerRetryCount` | Count | Viewer retry attempts before success |
| `UnexpectedDisconnectCount` | Count | Disconnects after connection was established |
| `JoinSSCallToOfferReceived` | Milliseconds | JoinSS API to SDP offer received |
| `JoinSSCallToSessionJoined` | Milliseconds | JoinSS API to peer connection established |
